### PR TITLE
Add Cynthion platform definitions

### DIFF
--- a/host/cynthion/__init__.py
+++ b/host/cynthion/__init__.py
@@ -5,6 +5,8 @@ from .cynthion import Cynthion
 from .cynthion import CynthionSingleton
 from .cynthion import CynthionBoard
 
+from . import gateware
+
 
 Cynthion = Cynthion  # pyflakes
 

--- a/host/cynthion/gateware/__init__.py
+++ b/host/cynthion/gateware/__init__.py
@@ -1,0 +1,14 @@
+import platform
+
+APOLLO_PLATFORMS = {
+    (0, 1): 'cynthion.gateware.platform:CynthionPlatformRev0D1',
+    (0, 2): 'cynthion.gateware.platform:CynthionPlatformRev0D2',
+    (0, 3): 'cynthion.gateware.platform:CynthionPlatformRev0D3',
+    (0, 4): 'cynthion.gateware.platform:CynthionPlatformRev0D4',
+    (0, 5): 'cynthion.gateware.platform:CynthionPlatformRev0D5',
+    (0, 6): 'cynthion.gateware.platform:CynthionPlatformRev0D6',
+    (0, 7): 'cynthion.gateware.platform:CynthionPlatformRev0D7',
+    (1, 0): 'cynthion.gateware.platform:CynthionPlatformRev1D0',
+    (1, 1): 'cynthion.gateware.platform:CynthionPlatformRev1D1',
+    (1, 2): 'cynthion.gateware.platform:CynthionPlatformRev1D2',
+}

--- a/host/cynthion/gateware/platform/__init__.py
+++ b/host/cynthion/gateware/platform/__init__.py
@@ -1,0 +1,16 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+from .cynthion_r0_1 import CynthionPlatformRev0D1
+from .cynthion_r0_2 import CynthionPlatformRev0D2
+from .cynthion_r0_3 import CynthionPlatformRev0D3
+from .cynthion_r0_4 import CynthionPlatformRev0D4
+from .cynthion_r0_5 import CynthionPlatformRev0D5
+from .cynthion_r0_6 import CynthionPlatformRev0D6
+from .cynthion_r0_7 import CynthionPlatformRev0D7
+from .cynthion_r1_0 import CynthionPlatformRev1D0
+from .cynthion_r1_1 import CynthionPlatformRev1D1
+from .cynthion_r1_2 import CynthionPlatformRev1D2

--- a/host/cynthion/gateware/platform/cynthion_r0_1.py
+++ b/host/cynthion/gateware/platform/cynthion_r0_1.py
@@ -1,0 +1,212 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from amaranth.build import Resource, Subsignal, Pins, PinsN, Attrs, Clock, DiffPairs, Connector
+from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
+
+from luna.gateware.platform.core import LUNAApolloPlatform
+from luna.gateware.architecture.car import LunaECP5DomainGenerator
+
+__all__ = ["CynthionPlatformRev0D1"]
+
+#
+# Note that r0.1+ have D+/D- swapped to avoid having to cross D+/D- in routing.
+#
+# This is supported by a PHY feature that allows you to swap pins 13 + 14.
+# You'll need to set
+#
+
+def ULPIResource(name, data_sites, clk_site, dir_site, nxt_site, stp_site, reset_site):
+    """ Generates a set of resources for a ULPI-connected USB PHY. """
+
+    return Resource(name, 0,
+        Subsignal("data",  Pins(data_sites,  dir="io")),
+        Subsignal("clk",   Pins(clk_site,    dir="o" )),
+        Subsignal("dir",   Pins(dir_site,    dir="i" )),
+        Subsignal("nxt",   Pins(nxt_site,    dir="i" )),
+        Subsignal("stp",   Pins(stp_site,    dir="o" )),
+        Subsignal("rst",   PinsN(reset_site, dir="o" )),
+        Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")
+    )
+
+
+class CynthionPlatformRev0D1(LUNAApolloPlatform, LatticeECP5Platform):
+    """ Board description for the pre-release r0.1 revision of Cynthion. """
+
+    name        = "Cynthion r0.1"
+
+    device      = "LFE5U-12F"
+    package     = "BG256"
+
+    # Different r0.1s have been produced with different speed grades; but there's
+    # some evidence (and some testing) that all of them are effectively speed grade 8.
+    # It's possible all ECP5 binning is artificial.
+    #
+    # We'll assume speed grade 8 unless the user overrides it on the command line.
+    speed       = os.getenv("ECP5_SPEED_GRADE", "8")
+
+    default_clk = "clk_60MHz"
+
+    # Provide the type that'll be used to create our clock domains.
+    clock_domain_generator = LunaECP5DomainGenerator
+
+    # By default, assume we'll be connecting via our target PHY.
+    default_usb_connection = "target_phy"
+
+    #
+    # Default clock frequencies for each of our clock domains.
+    #
+    # Different revisions have different FPGA speed grades, and thus the
+    # default frequencies will vary.
+    #
+    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
+        "fast": 240,
+        "sync": 120,
+        "usb":  60
+    }
+
+    #
+    # Preferred DRAM bus I/O (de)-skewing constants.
+    #
+    ram_timings = dict(
+        clock_skew = 64
+    )
+
+    # Provides any platform-specific ULPI registers necessary.
+    # This is the spot to put any platform-specific vendor registers that need
+    # to be written.
+    ulpi_extra_registers = {
+        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
+    }
+
+
+
+    #
+    # I/O resources.
+    #
+    resources   = [
+
+        # Primary, discrete 60MHz oscillator.
+        Resource("clk_60MHz", 0, Pins("A8", dir="i"),
+            Clock(60e6), Attrs(IO_TYPE="LVCMOS33")),
+
+        # Connection to our SPI flash; can be used to work with the flash
+        # from e.g. a bootloader.
+        Resource("spi_flash", 0,
+
+            # SCK is on pin 9; but doesn't have a traditional I/O buffer.
+            # Instead, we'll need to drive a clock into a USRMCLK instance.
+            # See interfaces/flash.py for more information.
+            Subsignal("sdi",  Pins("T8",  dir="o")),
+            Subsignal("sdo",  Pins("T7",  dir="i")),
+
+            # In r0.1, the chip select line can either be driven by the FPGA
+            # or by the Debug Controller. Accordingly, we'll mark the line as
+            # bidirectional, and let the user decide.
+            Subsignal("cs",   PinsN("N8", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        #
+        # Note: r0.1 has a DFM issue that makes it difficult to solder a BGA with
+        # reliable connections on the intended SCK pin (P12), and lacks a CS pin on the
+        # debug SPI; which seems like a silly omission.
+        #
+        # Accordingly, we're mapping the debug SPI and UART over the same pins, as the
+        # microcontroller can use either.
+        #
+
+        # UART connected to the debug controller; can be routed to a host via CDC-ACM.
+        Resource("uart", 0,
+            Subsignal("rx",   Pins("R14", dir="i")),
+            Subsignal("tx",   Pins("T14", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+
+        # SPI bus connected to the debug controller, for simple register exchanges.
+        # Note that the Debug Controller is the master on this bus.
+        Resource("debug_spi", 0,
+            Subsignal("sck",  Pins( "R14", dir="i")),
+            Subsignal("sdi",  Pins( "P13", dir="i")),
+            Subsignal("sdo",  Pins( "P11", dir="o")),
+            Subsignal("cs",   PinsN("T14", dir="i")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # FPGA-connected LEDs.
+        Resource("led",  5, PinsN("P15", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("led",  4, PinsN("N16", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("led",  3, PinsN("M15", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("led",  2, PinsN("M16", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("led",  1, PinsN("L15", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("led",  0, PinsN("L16", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # USB PHYs
+        ULPIResource("control_phy",
+            data_sites="R2 R1 P2 P1 N1 M2 M1 L2", clk_site="R4",
+            dir_site="T3", nxt_site="T2", stp_site="T4", reset_site="R3"),
+        ULPIResource("aux_phy",
+            data_sites="G2 G1 F2 F1 E1 D1 C1 B1", clk_site="K2",
+            dir_site="J1", nxt_site="H2", stp_site="J2", reset_site="K1"),
+        ULPIResource("target_phy",
+            data_sites="D16 E15 E16 F15 F16 G15 J16 K16", clk_site="B15",
+            dir_site="C15", nxt_site="C16", stp_site="B16", reset_site="G16"),
+
+        # legacy USB port names
+        ULPIResource("sideband_phy",
+            data_sites="R2 R1 P2 P1 N1 M2 M1 L2", clk_site="R4",
+            dir_site="T3", nxt_site="T2", stp_site="T4", reset_site="R3"),
+        ULPIResource("host_phy",
+            data_sites="G2 G1 F2 F1 E1 D1 C1 B1", clk_site="K2",
+            dir_site="J1", nxt_site="H2", stp_site="J2", reset_site="K1"),
+
+        # Target port power switching
+        # Note: the r0.1 boards that have been produced incorrectly use the AP22814B
+        # instead of the AP22814A. This inverts the load-switch enables.
+        #
+        Resource("power_a_port",       0, PinsN("C14", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("pass_through_vbus",  0, PinsN("D14", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_vbus_fault",  0, Pins("K15", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # HyperRAM (1V8 domain).
+        Resource("ram", 0,
+            # Note: our clock uses the pseudo-differential I/O present on the top tiles.
+            # This requires a recent version of trellis+nextpnr. If your build complains
+            # that LVCMOS18D is an invalid I/O type, you'll need to upgrade.
+            Subsignal("clk",   DiffPairs("B14", "A15", dir="o"), Attrs(IO_TYPE="LVCMOS18D")),
+            Subsignal("dq",    Pins("A11 B10 B12 A12 B11 A10 B9 A9", dir="io")),
+            Subsignal("rwds",  Pins( "A13", dir="io")),
+            Subsignal("cs",    PinsN("A14", dir="o")),
+            Subsignal("reset", PinsN("B13", dir="o")),
+            Attrs(IO_TYPE="LVCMOS18", SLEWRATE="FAST")
+        ),
+
+        # User I/O connections.
+        Resource("user_io", 0, Pins("A5", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        Resource("user_io", 1, Pins("A4", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        Resource("user_io", 2, Pins("A3", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        Resource("user_io", 3, Pins("A2", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+    ]
+
+    connectors = [
+
+        # User I/O connector.
+        Connector("user_io", 0, """
+            A5  -  A2
+            A4  -  A3
+        """)
+
+    ]
+
+    def toolchain_prepare(self, fragment, name, **kwargs):
+        overrides = {
+            'ecppack_opts': '--compress --idcode {} --freq 38.8'.format(0x21111043)
+        }
+
+        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/host/cynthion/gateware/platform/cynthion_r0_2.py
+++ b/host/cynthion/gateware/platform/cynthion_r0_2.py
@@ -1,0 +1,172 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from amaranth.build import *
+from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
+from amaranth_boards.resources import *
+
+from luna.gateware.platform.core import LUNAApolloPlatform
+from luna.gateware.architecture.car import LunaECP5DomainGenerator
+
+__all__ = ["CynthionPlatformRev0D2"]
+
+#
+# Note that r0.2+ have D+/D- swapped to avoid having to cross D+/D- in routing.
+#
+# This is supported by a PHY feature that allows you to swap pins 13 + 14.
+#
+
+class CynthionPlatformRev0D2(LUNAApolloPlatform, LatticeECP5Platform):
+    """ Board description for the pre-release r0.2 revision of Cynthion. """
+
+    name        = "Cynthion r0.2"
+
+    device      = "LFE5U-12F"
+    package     = "BG256"
+    speed       = os.getenv("ECP5_SPEED_GRADE", "8")
+
+    default_clk = "clk_60MHz"
+
+    # Provide the type that'll be used to create our clock domains.
+    clock_domain_generator = LunaECP5DomainGenerator
+
+    # By default, assume we'll be connecting via our target PHY.
+    default_usb_connection = "target_phy"
+
+    #
+    # Default clock frequencies for each of our clock domains.
+    #
+    # Different revisions have different FPGA speed grades, and thus the
+    # default frequencies will vary.
+    #
+    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
+        "fast": 240,
+        "sync": 120,
+        "usb":  60
+    }
+
+    #
+    # Preferred DRAM bus I/O (de)-skewing constants.
+    #
+    ram_timings = dict(
+        clock_skew = 64
+    )
+
+    # Provides any platform-specific ULPI registers necessary.
+    # This is the spot to put any platform-specific vendor registers that need
+    # to be written.
+    ulpi_extra_registers = {
+        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
+    }
+
+
+    #
+    # I/O resources.
+    #
+    resources   = [
+
+        # Primary, discrete 60MHz oscillator.
+        Resource("clk_60MHz", 0, Pins("A7", dir="i"),
+            Clock(60e6), Attrs(IO_TYPE="LVCMOS33")),
+
+        # Connection to our SPI flash; can be used to work with the flash
+        # from e.g. a bootloader.
+        Resource("spi_flash", 0,
+
+            # SCK is on pin 9; but doesn't have a traditional I/O buffer.
+            # Instead, we'll need to drive a clock into a USRMCLK instance.
+            # See interfaces/flash.py for more information.
+            Subsignal("sdi",  Pins("T8",  dir="o")),
+            Subsignal("sdo",  Pins("T7",  dir="i")),
+
+            # In r0.2, the chip select line can either be driven by the FPGA
+            # or by the Debug Controller. Accordingly, we'll mark the line as
+            # bidirectional, and let the user decide.
+            Subsignal("cs",   PinsN("N8", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # UART connected to the debug controller; can be routed to a host via CDC-ACM.
+        UARTResource(0, rx="R14", tx="T14", attrs=Attrs(IO_TYPE="LVCMOS33")),
+
+        # SPI bus connected to the debug controller, for simple register exchanges.
+        # Note that the Debug Controller is the controller on this bus.
+        Resource("debug_spi", 0,
+            Subsignal("sck",  Pins( "R13", dir="i")),
+            Subsignal("sdi",  Pins( "P13", dir="i")),
+            Subsignal("sdo",  Pins( "P11", dir="o")),
+            Subsignal("cs",   PinsN("T13", dir="i")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # FPGA-connected LEDs.
+        *LEDResources(pins="L16 L15 M16 M15 N16 P15", attrs=Attrs(IO_TYPE="LVCMOS33"), invert=True),
+
+        # USB PHYs
+        ULPIResource("control_phy", 0,
+            data="R2 R1 P2 P1 N1 M2 M1 L2", clk="R4", clk_dir='o',
+            dir="T3", nxt="T2", stp="T4", rst="R3", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("aux_phy", 0,
+            data="G2 G1 F2 F1 E1 D1 C1 B1", clk="K2", clk_dir='o',
+            dir="J1", nxt="H2", stp="J2", rst="K1", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("target_phy", 0,
+            data="D16 E15 E16 F15 F16 G15 J16 K16", clk="B15", clk_dir='o',
+            dir="C15", nxt="C16", stp="B16", rst="G16", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # legacy USB port names
+        ULPIResource("sideband_phy", 0,
+            data="R2 R1 P2 P1 N1 M2 M1 L2", clk="R4", clk_dir='o',
+            dir="T3", nxt="T2", stp="T4", rst="R3", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("host_phy", 0,
+            data="G2 G1 F2 F1 E1 D1 C1 B1", clk="K2", clk_dir='o',
+            dir="J1", nxt="H2", stp="J2", rst="K1", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # Target port power switching.
+        Resource("power_a_port",       0, Pins("C14", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("pass_through_vbus",  0, Pins("D14", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_vbus_fault",  0, Pins("K15", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # HyperRAM (1V8 domain).
+        Resource("ram", 0,
+            # Note: our clock uses the pseudo-differential I/O present on the top tiles.
+            # This requires a recent version of trellis+nextpnr. If your build complains
+            # that LVCMOS18D is an invalid I/O type, you'll need to upgrade.
+            Subsignal("clk",   DiffPairs("B14", "A15", dir="o"), Attrs(IO_TYPE="LVCMOS18D")),
+            Subsignal("dq",    Pins("A11 B10 B12 A12 B11 A10 B9 A9", dir="io")),
+            Subsignal("rwds",  Pins( "A13", dir="io")),
+            Subsignal("cs",    PinsN("A14", dir="o")),
+            Subsignal("reset", PinsN("B13", dir="o")),
+            Attrs(IO_TYPE="LVCMOS18", SLEWRATE="FAST")
+        ),
+
+        # User I/O connections.
+        Resource("user_io", 0, Pins("A5", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        Resource("user_io", 1, Pins("A4", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        Resource("user_io", 2, Pins("A3", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        Resource("user_io", 3, Pins("A2", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+    ]
+
+    connectors = [
+        Connector("user_io", 0, """
+            A5  -  A2
+            A4  -  A3
+        """)
+    ]
+
+    def toolchain_prepare(self, fragment, name, **kwargs):
+        overrides = {
+            'ecppack_opts': '--compress --freq 38.8'
+        }
+
+        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)
+

--- a/host/cynthion/gateware/platform/cynthion_r0_3.py
+++ b/host/cynthion/gateware/platform/cynthion_r0_3.py
@@ -1,0 +1,183 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from amaranth.build import *
+from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
+from amaranth_boards.resources import *
+
+from luna.gateware.platform.core import LUNAApolloPlatform
+from luna.gateware.architecture.car import LunaECP5DomainGenerator
+
+__all__ = ["CynthionPlatformRev0D3"]
+
+#
+# Note that r0.3 have D+/D- swapped to avoid having to cross D+/D- in routing.
+#
+# This is supported by a PHY feature that allows you to swap pins 13 + 14.
+#
+
+class CynthionPlatformRev0D3(LUNAApolloPlatform, LatticeECP5Platform):
+    """ Board description for the pre-release r0.3 revision of Cynthion. """
+
+    name        = "Cynthion r0.3"
+
+    device      = "LFE5U-12F"
+    package     = "BG256"
+    speed       = os.getenv("ECP5_SPEED_GRADE", "8")
+
+    default_clk = "clk_60MHz"
+
+    # Provide the type that'll be used to create our clock domains.
+    clock_domain_generator = LunaECP5DomainGenerator
+
+    # By default, assume we'll be connecting via our target PHY.
+    default_usb_connection = "target_phy"
+
+    #
+    # Default clock frequencies for each of our clock domains.
+    #
+    # Different revisions have different FPGA speed grades, and thus the
+    # default frequencies will vary.
+    #
+    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
+        "fast": 240,
+        "sync": 120,
+        "usb":  60
+    }
+
+    #
+    # Preferred DRAM bus I/O (de)-skewing constants.
+    #
+    ram_timings = dict(
+        clock_skew = 16
+    )
+
+    # Provides any platform-specific ULPI registers necessary.
+    # This is the spot to put any platform-specific vendor registers that need
+    # to be written.
+    ulpi_extra_registers = {
+        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
+    }
+
+
+    #
+    # I/O resources.
+    #
+    resources   = [
+
+        # Primary, discrete 60MHz oscillator.
+        Resource("clk_60MHz", 0, Pins("A8", dir="i"),
+            Clock(60e6), Attrs(IO_TYPE="LVCMOS33")),
+
+        # Connection to our SPI flash; can be used to work with the flash
+        # from e.g. a bootloader.
+        Resource("spi_flash", 0,
+
+            # SCK is on pin 9; but doesn't have a traditional I/O buffer.
+            # Instead, we'll need to drive a clock into a USRMCLK instance.
+            # See interfaces/flash.py for more information.
+            Subsignal("sdi",  Pins("T8",  dir="o")),
+            Subsignal("sdo",  Pins("T7",  dir="i")),
+            Subsignal("cs",   PinsN("N8", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # Note: UART pins R14 and T14 are connected to JTAG pins R11 (TDI)
+        # and T11 (TMS) respectively, so the microcontroller can use either
+        # function but not both simultaneously.
+
+        # UART connected to the debug controller; can be routed to a host via CDC-ACM.
+        Resource("uart", 0,
+            Subsignal("rx",  Pins("R14",  dir="i")),
+            Subsignal("tx",  Pins("T14",  dir="oe"), Attrs(PULLMODE="UP")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # SPI bus connected to test points for simple register exchanges.
+        # The FPGA acts as peripheral, not controller.
+        Resource("debug_spi", 0,
+            Subsignal("sck",  Pins( "R13", dir="i")),
+            Subsignal("sdi",  Pins( "P13", dir="i")),
+            Subsignal("sdo",  Pins( "P11", dir="o")),
+            Subsignal("cs",   PinsN("T13", dir="i")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # FPGA-connected LEDs numbered 5-0.
+        *LEDResources(pins="P14 P16 P15 R16 R15 T15", attrs=Attrs(IO_TYPE="LVCMOS33"), invert=True),
+
+        # USB PHYs
+        ULPIResource("control_phy", 0,
+            data="R1 P3 P1 P2 N1 M2 M1 L2", clk="P4", clk_dir='o',
+            dir="T2", nxt="R2", stp="R3", rst="T3", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("aux_phy", 0,
+            data="F1 F2 E1 E2 D1 E3 C1 C2", clk="J1", clk_dir='o',
+            dir="G1", nxt="G2", stp="H2", rst="J2", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("target_phy", 0,
+            data="E16 F14 F16 F15 G16 G15 H15 J16", clk="C15", clk_dir='o',
+            dir="D16", nxt="E15", stp="D14", rst="C16", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # legacy USB port names
+        ULPIResource("sideband_phy", 0,
+            data="R1 P3 P1 P2 N1 M2 M1 L2", clk="P4", clk_dir='o',
+            dir="T2", nxt="R2", stp="R3", rst="T3", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("host_phy", 0,
+            data="F1 F2 E1 E2 D1 E3 C1 C2", clk="J1", clk_dir='o',
+            dir="G1", nxt="G2", stp="H2", rst="J2", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # Target port power switching.
+        #
+        # power_c_port does the reverse of pass_through_vbus, passing power
+        # from the Type-A port to the Type-C port. It is intended to be used in
+        # conjunction with power_a_port, supplying VBUS to both target ports.
+
+        Resource("power_a_port",         0, Pins("C14", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("power_c_port",         0, Pins("F13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("pass_through_vbus",    0, Pins("B16", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_c_to_a_fault",  0, Pins("F12", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_a_to_c_fault",  0, Pins("E14", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_5v_to_a_fault", 0, Pins("B15", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # HyperRAM (3V3 domain).
+        Resource("ram", 0,
+            # Note: our clock uses the pseudo-differential I/O present on the top tiles.
+            # This requires a recent version of trellis+nextpnr. If your build complains
+            # that LVCMOS33D is an invalid I/O type, you'll need to upgrade.
+            Subsignal("clk",   DiffPairs("B14", "A15", dir="o"), Attrs(IO_TYPE="LVCMOS33D")),
+            Subsignal("dq",    Pins("A11 B10 B12 A12 B11 A10 B9 A9", dir="io")),
+            Subsignal("rwds",  Pins( "A13", dir="io")),
+            Subsignal("cs",    PinsN("A14", dir="o")),
+            Subsignal("reset", PinsN("B13", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")
+        ),
+
+        # User I/O connections (SMA connectors).
+        Resource("user_io", 0, Pins("C3", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        Resource("user_io", 1, Pins("D3", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # Convenience references.
+        Resource("user_pmod", 0, Pins("A3 A4 A5 A6 C6 B6 C7 B7", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_pmod", 1, Pins("M5 N5 M4 N3 L4 L5 K4 K5", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+    ]
+
+    connectors = [
+        Connector("pmod", 0, "A3 A4 A5 A6 - - C6 B6 C7 B7 - -"), # Pmod A
+        Connector("pmod", 1, "M5 N5 M4 N3 - - L4 L5 K4 K5 - -"), # Pmod B
+    ]
+
+    def toolchain_prepare(self, fragment, name, **kwargs):
+        overrides = {
+            'ecppack_opts': '--compress --freq 38.8'
+        }
+
+        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/host/cynthion/gateware/platform/cynthion_r0_4.py
+++ b/host/cynthion/gateware/platform/cynthion_r0_4.py
@@ -1,0 +1,185 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from amaranth.build import *
+from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
+from amaranth_boards.resources import *
+
+from luna.gateware.platform.core import LUNAApolloPlatform
+from luna.gateware.architecture.car import LunaECP5DomainGenerator
+
+__all__ = ["CynthionPlatformRev0D4"]
+
+#
+# Note that r0.4 have D+/D- swapped to avoid having to cross D+/D- in routing.
+#
+# This is supported by a PHY feature that allows you to swap pins 13 + 14.
+#
+
+class CynthionPlatformRev0D4(LUNAApolloPlatform, LatticeECP5Platform):
+    """ Board description for the pre-release r0.4 revision of Cynthion. """
+
+    name        = "Cynthion r0.4"
+
+    device      = "LFE5U-12F"
+    package     = "BG256"
+    speed       = os.getenv("ECP5_SPEED_GRADE", "8")
+
+    default_clk = "clk_60MHz"
+
+    # Provide the type that'll be used to create our clock domains.
+    clock_domain_generator = LunaECP5DomainGenerator
+
+    # By default, assume we'll be connecting via our target PHY.
+    default_usb_connection = "target_phy"
+
+    #
+    # Default clock frequencies for each of our clock domains.
+    #
+    # Different revisions have different FPGA speed grades, and thus the
+    # default frequencies will vary.
+    #
+    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
+        "fast": 240,
+        "sync": 120,
+        "usb":  60
+    }
+
+    #
+    # Preferred DRAM bus I/O (de)-skewing constants.
+    #
+    ram_timings = dict(
+        # Set max skew to meet IO setup times
+        # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
+        clock_skew = 127
+    )
+
+    # Provides any platform-specific ULPI registers necessary.
+    # This is the spot to put any platform-specific vendor registers that need
+    # to be written.
+    ulpi_extra_registers = {
+        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
+    }
+
+
+    #
+    # I/O resources.
+    #
+    resources   = [
+
+        # Primary, discrete 60MHz oscillator.
+        Resource("clk_60MHz", 0, Pins("A8", dir="i"),
+            Clock(60e6), Attrs(IO_TYPE="LVCMOS33")),
+
+        # Connection to our SPI flash; can be used to work with the flash
+        # from e.g. a bootloader.
+        Resource("spi_flash", 0,
+
+            # SCK is on pin 9; but doesn't have a traditional I/O buffer.
+            # Instead, we'll need to drive a clock into a USRMCLK instance.
+            # See interfaces/flash.py for more information.
+            Subsignal("sdi",  Pins("T8",  dir="o")),
+            Subsignal("sdo",  Pins("T7",  dir="i")),
+            Subsignal("cs",   PinsN("N8", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # Note: UART pins R14 and T14 are connected to JTAG pins R11 (TDI)
+        # and T11 (TMS) respectively, so the microcontroller can use either
+        # function but not both simultaneously.
+
+        # UART connected to the debug controller; can be routed to a host via CDC-ACM.
+        Resource("uart", 0,
+            Subsignal("rx",  Pins("R14",  dir="i")),
+            Subsignal("tx",  Pins("T14",  dir="oe"), Attrs(PULLMODE="UP")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # SPI bus connected to test points for simple register exchanges.
+        # The FPGA acts as peripheral, not controller.
+        Resource("debug_spi", 0,
+            Subsignal("sck",  Pins( "R13", dir="i")),
+            Subsignal("sdi",  Pins( "P13", dir="i")),
+            Subsignal("sdo",  Pins( "P11", dir="o")),
+            Subsignal("cs",   PinsN("T13", dir="i")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # FPGA-connected LEDs numbered 5-0.
+        *LEDResources(pins="P14 P16 P15 R16 R15 T15", attrs=Attrs(IO_TYPE="LVCMOS33"), invert=True),
+
+        # USB PHYs
+        ULPIResource("control_phy", 0,
+            data="R1 P3 P1 P2 N1 M2 M1 L2", clk="P4", clk_dir='o',
+            dir="T2", nxt="R2", stp="R3", rst="T3", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("aux_phy", 0,
+            data="F1 F2 E1 E2 D1 E3 C1 C2", clk="J1", clk_dir='o',
+            dir="G1", nxt="G2", stp="H2", rst="J2", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("target_phy", 0,
+            data="E16 F14 F16 F15 G16 G15 H15 J16", clk="C15", clk_dir='o',
+            dir="D16", nxt="E15", stp="D14", rst="C16", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # legacy USB port names
+        ULPIResource("sideband_phy", 0,
+            data="R1 P3 P1 P2 N1 M2 M1 L2", clk="P4", clk_dir='o',
+            dir="T2", nxt="R2", stp="R3", rst="T3", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("host_phy", 0,
+            data="F1 F2 E1 E2 D1 E3 C1 C2", clk="J1", clk_dir='o',
+            dir="G1", nxt="G2", stp="H2", rst="J2", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # Target port power switching.
+        #
+        # power_c_port does the reverse of pass_through_vbus, passing power
+        # from the Type-A port to the Type-C port. It is intended to be used in
+        # conjunction with power_a_port, supplying VBUS to both target ports.
+
+        Resource("power_a_port",         0, Pins("C14", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("power_c_port",         0, Pins("F13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("pass_through_vbus",    0, Pins("B16", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_c_to_a_fault",  0, Pins("F12", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_a_to_c_fault",  0, Pins("E14", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_5v_to_a_fault", 0, Pins("B15", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # HyperRAM (3V3 domain).
+        Resource("ram", 0,
+            # Note: our clock uses the pseudo-differential I/O present on the top tiles.
+            # This requires a recent version of trellis+nextpnr. If your build complains
+            # that LVCMOS33D is an invalid I/O type, you'll need to upgrade.
+            Subsignal("clk",   DiffPairs("B14", "A15", dir="o"), Attrs(IO_TYPE="LVCMOS33D")),
+            Subsignal("dq",    Pins("A11 B10 B12 A12 B11 A10 B9 A9", dir="io")),
+            Subsignal("rwds",  Pins( "A13", dir="io")),
+            Subsignal("cs",    PinsN("A14", dir="o")),
+            Subsignal("reset", PinsN("B13", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")
+        ),
+
+        # User I/O connections (SMA connectors).
+        Resource("user_io", 0, Pins("C3", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        Resource("user_io", 1, Pins("D3", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # Convenience references.
+        Resource("user_pmod", 0, Pins("A3 A4 A5 A6 C6 B6 C7 B7", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_pmod", 1, Pins("M5 N5 M4 N3 L4 L5 K4 K5", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+    ]
+
+    connectors = [
+        Connector("pmod", 0, "A3 A4 A5 A6 - - C6 B6 C7 B7 - -"), # Pmod A
+        Connector("pmod", 1, "M5 N5 M4 N3 - - L4 L5 K4 K5 - -"), # Pmod B
+    ]
+
+    def toolchain_prepare(self, fragment, name, **kwargs):
+        overrides = {
+            'ecppack_opts': '--compress --freq 38.8'
+        }
+
+        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/host/cynthion/gateware/platform/cynthion_r0_5.py
+++ b/host/cynthion/gateware/platform/cynthion_r0_5.py
@@ -1,0 +1,185 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from amaranth.build import *
+from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
+from amaranth_boards.resources import *
+
+from luna.gateware.platform.core import LUNAApolloPlatform
+from luna.gateware.architecture.car import LunaECP5DomainGenerator
+
+__all__ = ["CynthionPlatformRev0D5"]
+
+#
+# Note that r0.5 have D+/D- swapped to avoid having to cross D+/D- in routing.
+#
+# This is supported by a PHY feature that allows you to swap pins 13 + 14.
+#
+
+class CynthionPlatformRev0D5(LUNAApolloPlatform, LatticeECP5Platform):
+    """ Board description for the pre-release r0.5 revision of Cynthion. """
+
+    name        = "Cynthion r0.5"
+
+    device      = "LFE5U-12F"
+    package     = "BG256"
+    speed       = os.getenv("ECP5_SPEED_GRADE", "8")
+
+    default_clk = "clk_60MHz"
+
+    # Provide the type that'll be used to create our clock domains.
+    clock_domain_generator = LunaECP5DomainGenerator
+
+    # By default, assume we'll be connecting via our target PHY.
+    default_usb_connection = "target_phy"
+
+    #
+    # Default clock frequencies for each of our clock domains.
+    #
+    # Different revisions have different FPGA speed grades, and thus the
+    # default frequencies will vary.
+    #
+    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
+        "fast": 240,
+        "sync": 120,
+        "usb":  60
+    }
+
+    #
+    # Preferred DRAM bus I/O (de)-skewing constants.
+    #
+    ram_timings = dict(
+        # Set max skew to meet IO setup times
+        # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
+        clock_skew = 127
+    )
+
+    # Provides any platform-specific ULPI registers necessary.
+    # This is the spot to put any platform-specific vendor registers that need
+    # to be written.
+    ulpi_extra_registers = {
+        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
+    }
+
+
+    #
+    # I/O resources.
+    #
+    resources   = [
+
+        # Primary, discrete 60MHz oscillator.
+        Resource("clk_60MHz", 0, Pins("A8", dir="i"),
+            Clock(60e6), Attrs(IO_TYPE="LVCMOS33")),
+
+        # Connection to our SPI flash; can be used to work with the flash
+        # from e.g. a bootloader.
+        Resource("spi_flash", 0,
+
+            # SCK is on pin 9; but doesn't have a traditional I/O buffer.
+            # Instead, we'll need to drive a clock into a USRMCLK instance.
+            # See interfaces/flash.py for more information.
+            Subsignal("sdi",  Pins("T8",  dir="o")),
+            Subsignal("sdo",  Pins("T7",  dir="i")),
+            Subsignal("cs",   PinsN("N8", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # Note: UART pins R14 and T14 are connected to JTAG pins R11 (TDI)
+        # and T11 (TMS) respectively, so the microcontroller can use either
+        # function but not both simultaneously.
+
+        # UART connected to the debug controller; can be routed to a host via CDC-ACM.
+        Resource("uart", 0,
+            Subsignal("rx",  Pins("R14",  dir="i")),
+            Subsignal("tx",  Pins("T14",  dir="oe"), Attrs(PULLMODE="UP")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # SPI bus connected to test points for simple register exchanges.
+        # The FPGA acts as peripheral, not controller.
+        Resource("debug_spi", 0,
+            Subsignal("sck",  Pins( "R13", dir="i")),
+            Subsignal("sdi",  Pins( "P13", dir="i")),
+            Subsignal("sdo",  Pins( "P11", dir="o")),
+            Subsignal("cs",   PinsN("T13", dir="i")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # FPGA-connected LEDs numbered 5-0.
+        *LEDResources(pins="P14 P16 P15 R16 R15 T15", attrs=Attrs(IO_TYPE="LVCMOS33"), invert=True),
+
+        # USB PHYs
+        ULPIResource("control_phy", 0,
+            data="R1 P3 P1 P2 N1 M2 M1 L2", clk="P4", clk_dir='o',
+            dir="T2", nxt="R2", stp="R3", rst="T3", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("aux_phy", 0,
+            data="F1 F2 E1 E2 D1 E3 C1 C2", clk="J1", clk_dir='o',
+            dir="G1", nxt="G2", stp="H2", rst="J2", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("target_phy", 0,
+            data="E16 F14 F16 F15 G16 G15 H15 J16", clk="C15", clk_dir='o',
+            dir="D16", nxt="E15", stp="D14", rst="C16", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # legacy USB port names
+        ULPIResource("sideband_phy", 0,
+            data="R1 P3 P1 P2 N1 M2 M1 L2", clk="P4", clk_dir='o',
+            dir="T2", nxt="R2", stp="R3", rst="T3", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("host_phy", 0,
+            data="F1 F2 E1 E2 D1 E3 C1 C2", clk="J1", clk_dir='o',
+            dir="G1", nxt="G2", stp="H2", rst="J2", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # Target port power switching.
+        #
+        # power_c_port does the reverse of pass_through_vbus, passing power
+        # from the Type-A port to the Type-C port. It is intended to be used in
+        # conjunction with power_a_port, supplying VBUS to both target ports.
+
+        Resource("power_a_port",         0, Pins("C14", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("power_c_port",         0, Pins("F13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("pass_through_vbus",    0, Pins("B16", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_c_to_a_fault",  0, Pins("F12", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_a_to_c_fault",  0, Pins("E14", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_5v_to_a_fault", 0, Pins("B15", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # HyperRAM (3V3 domain).
+        Resource("ram", 0,
+            # Note: our clock uses the pseudo-differential I/O present on the top tiles.
+            # This requires a recent version of trellis+nextpnr. If your build complains
+            # that LVCMOS33D is an invalid I/O type, you'll need to upgrade.
+            Subsignal("clk",   DiffPairs("B14", "A15", dir="o"), Attrs(IO_TYPE="LVCMOS33D")),
+            Subsignal("dq",    Pins("A11 B10 B12 A12 B11 A10 B9 A9", dir="io")),
+            Subsignal("rwds",  Pins( "A13", dir="io")),
+            Subsignal("cs",    PinsN("A14", dir="o")),
+            Subsignal("reset", PinsN("B13", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")
+        ),
+
+        # User I/O connections (SMA connectors).
+        Resource("user_io", 0, Pins("C3", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        Resource("user_io", 1, Pins("D3", dir="io"), Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # Convenience references.
+        Resource("user_pmod", 0, Pins("A3 A4 A5 A6 C6 B6 C7 B7", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_pmod", 1, Pins("M5 N5 M4 N3 L4 L5 K4 K5", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+    ]
+
+    connectors = [
+        Connector("pmod", 0, "A3 A4 A5 A6 - - C6 B6 C7 B7 - -"), # Pmod A
+        Connector("pmod", 1, "M5 N5 M4 N3 - - L4 L5 K4 K5 - -"), # Pmod B
+    ]
+
+    def toolchain_prepare(self, fragment, name, **kwargs):
+        overrides = {
+            'ecppack_opts': '--compress --freq 38.8'
+        }
+
+        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/host/cynthion/gateware/platform/cynthion_r0_6.py
+++ b/host/cynthion/gateware/platform/cynthion_r0_6.py
@@ -1,0 +1,204 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from amaranth.build import *
+from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
+from amaranth_boards.resources import *
+
+from luna.gateware.platform.core import LUNAApolloPlatform
+from luna.gateware.architecture.car import LunaECP5DomainGenerator
+
+__all__ = ["CynthionPlatformRev0D6"]
+
+class CynthionPlatformRev0D6(LUNAApolloPlatform, LatticeECP5Platform):
+    """ Board description for Cynthion r0.6 """
+
+    name        = "Cynthion r0.6"
+
+    device      = "LFE5U-12F"
+    package     = "BG256"
+    speed       = os.getenv("ECP5_SPEED_GRADE", "8")
+
+    default_clk = "clk_60MHz"
+
+    # Provide the type that'll be used to create our clock domains.
+    clock_domain_generator = LunaECP5DomainGenerator
+
+    # By default, assume we'll be connecting via our target PHY.
+    default_usb_connection = "target_phy"
+
+    #
+    # Default clock frequencies for each of our clock domains.
+    #
+    # Different revisions have different FPGA speed grades, and thus the
+    # default frequencies will vary.
+    #
+    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
+        "fast": 240,
+        "sync": 120,
+        "usb":  60
+    }
+
+    #
+    # Preferred DRAM bus I/O (de)-skewing constants.
+    #
+    ram_timings = dict(
+        # Set max skew to meet IO setup times
+        # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
+        clock_skew = 127
+    )
+
+    # Provides any platform-specific ULPI registers necessary.
+    # This is the spot to put any platform-specific vendor registers that need
+    # to be written.
+    ulpi_extra_registers = {
+        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
+    }
+
+    #
+    # I/O resources.
+    #
+    resources   = [
+
+        # Primary, discrete 60MHz oscillator.
+        Resource("clk_60MHz", 0, Pins("A8", dir="i"),
+            Clock(60e6), Attrs(IO_TYPE="LVCMOS33")),
+
+        # Connection to our SPI flash; can be used to work with the flash
+        # from e.g. a bootloader.
+        Resource("spi_flash", 0,
+
+            # SCK is on pin 9; but doesn't have a traditional I/O buffer.
+            # Instead, we'll need to drive a clock into a USRMCLK instance.
+            # See interfaces/flash.py for more information.
+            Subsignal("sdi",  Pins("T8",  dir="o")),
+            Subsignal("sdo",  Pins("T7",  dir="i")),
+            Subsignal("cs",   PinsN("N8", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # Note: UART pins R14 and T14 are connected to JTAG pins R11 (TDI)
+        # and T11 (TMS) respectively, so the microcontroller can use either
+        # function but not both simultaneously.
+
+        # UART connected to the debug controller; can be routed to a host via CDC-ACM.
+        Resource("uart", 0,
+            Subsignal("rx",  Pins("R14",  dir="i")),
+            Subsignal("tx",  Pins("T14",  dir="oe"), Attrs(PULLMODE="UP")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # interrupt output to send signal to microcontroller
+        Resource("int", 0, Pins("R8", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # USER button
+        Resource("button_user", 0, PinsN("M14", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+
+        # output signal connected to PROGRAMN to trigger FPGA reconfiguration
+        Resource("self_program", 0, PinsN("T13", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+
+        # FPGA LEDs
+        *LEDResources(pins="E13 C13 B14 A15 D12 C11", attrs=Attrs(IO_TYPE="LVCMOS33"), invert=True),
+
+        # USB PHYs
+        ULPIResource("control_phy", 0,
+            data="N16 N14 P16 P15 R16 R15 T15 P14", clk="L14", clk_dir='o',
+            dir="M16", nxt="M15", stp="L15", rst="L16", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("aux_phy", 0,
+            data="J16 K15 K16 J13 J14 H13 H14 K14", clk="F16", clk_dir='o',
+            dir="H15", nxt="J15", stp="G16", rst="G15", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("target_phy", 0,
+            data="R2 R1 P2 P1 N3 N1 M2 M1", clk="T4", clk_dir='o',
+            dir="R3", nxt="T2", stp="T3", rst="R4", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # direct connection to TARGET USB D+/D-
+        Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+
+        # USB Type-C controllers and pins
+        Resource("target_type_c", 0,
+            Subsignal("scl",   Pins( "A4", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "C4", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("int",   PinsN("A3", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("fault", PinsN("D4", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("sbu1",  Pins( "A2", dir="io")),
+            Subsignal("sbu2",  Pins( "E4", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+        Resource("aux_type_c", 0,
+            Subsignal("scl",   Pins( "D16", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "E15", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("int",   PinsN("H12", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("fault", PinsN("G14", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("sbu1",  Pins( "E16", dir="io")),
+            Subsignal("sbu2",  Pins( "F15", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # power input shutoff
+        Resource("control_vbus_in_en", 0, PinsN("K13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("aux_vbus_in_en",     0, PinsN("L13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # VBUS passthrough
+        #
+        # VBUS on each of the Type-C ports can be connected to TARGET A through
+        # a bidirectional switch. If any of these switches is enabled, TARGET A
+        # is considered an output. An additional switch can be enabled to pass
+        # VBUS through to another port in addition to TARGET A.
+        #
+        # The TARGET C switch is enabled by default, even when Cynthion is
+        # powered off, enabling VBUS passthrough from TARGET C to TARGET A.
+
+        Resource("target_c_vbus_en",   0, PinsN("K5", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+        Resource("control_vbus_en",    0, Pins("L1", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("aux_vbus_en",        0, Pins("L2", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_a_discharge", 0, Pins("K4", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # voltage and current monitor
+        Resource("power_monitor", 0,
+            Subsignal("scl",   Pins( "C6", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "D6", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("pwrdn", PinsN("C7", dir="o" )),
+            Subsignal("slow",  Pins( "D5", dir="io")),
+            Subsignal("gpio",  Pins( "D7", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")
+        ),
+
+        # HyperRAM
+        Resource("ram", 0,
+            Subsignal("clk",   DiffPairs("C3", "D3", dir="o"), Attrs(IO_TYPE="LVCMOS33D")),
+            Subsignal("dq",    Pins("F2 B1 C2 E1 E3 E2 F3 G4", dir="io")),
+            Subsignal("rwds",  Pins( "D1", dir="io")),
+            Subsignal("cs",    PinsN("B2", dir="o")),
+            Subsignal("reset", PinsN("C1", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")
+        ),
+
+        # User I/O connections.
+        Resource("user_pmod", 0, Pins("C9 C8 D11 C12 B8 D8 D9 C10", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_pmod", 1, Pins("B4 B5 B6 B7 C5 A5 A6 A7", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_mezzanine", 0,
+                Pins("B9 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11", dir="io"),
+                Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+    ]
+
+    connectors = [
+        Connector("pmod", 0, "C9 C8 D11 C12 - - B8 D8 D9 C10 - -"), # PMOD A
+        Connector("pmod", 1, "B4 B5 B6 B7 - - C5 A5 A6 A7 - -"), # PMOD B
+        Connector("mezzanine", 0,
+            "- - B9 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),
+    ]
+
+    def toolchain_prepare(self, fragment, name, **kwargs):
+        overrides = {
+            'ecppack_opts': '--compress --freq 38.8'
+        }
+
+        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/host/cynthion/gateware/platform/cynthion_r0_7.py
+++ b/host/cynthion/gateware/platform/cynthion_r0_7.py
@@ -1,0 +1,204 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from amaranth.build import *
+from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
+from amaranth_boards.resources import *
+
+from luna.gateware.platform.core import LUNAApolloPlatform
+from luna.gateware.architecture.car import LunaECP5DomainGenerator
+
+__all__ = ["CynthionPlatformRev0D7"]
+
+class CynthionPlatformRev0D7(LUNAApolloPlatform, LatticeECP5Platform):
+    """ Board description for Cynthion r0.7 """
+
+    name        = "Cynthion r0.7"
+
+    device      = "LFE5U-25F"
+    package     = "BG256"
+    speed       = os.getenv("ECP5_SPEED_GRADE", "8")
+
+    default_clk = "clk_60MHz"
+
+    # Provide the type that'll be used to create our clock domains.
+    clock_domain_generator = LunaECP5DomainGenerator
+
+    # By default, assume we'll be connecting via our target PHY.
+    default_usb_connection = "target_phy"
+
+    #
+    # Default clock frequencies for each of our clock domains.
+    #
+    # Different revisions have different FPGA speed grades, and thus the
+    # default frequencies will vary.
+    #
+    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
+        "fast": 240,
+        "sync": 120,
+        "usb":  60
+    }
+
+    #
+    # Preferred DRAM bus I/O (de)-skewing constants.
+    #
+    ram_timings = dict(
+        # Set max skew to meet IO setup times
+        # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
+        clock_skew = 127
+    )
+
+    # Provides any platform-specific ULPI registers necessary.
+    # This is the spot to put any platform-specific vendor registers that need
+    # to be written.
+    ulpi_extra_registers = {
+        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
+    }
+
+    #
+    # I/O resources.
+    #
+    resources   = [
+
+        # Primary, discrete 60MHz oscillator.
+        Resource("clk_60MHz", 0, Pins("A8", dir="i"),
+            Clock(60e6), Attrs(IO_TYPE="LVCMOS33")),
+
+        # Connection to our SPI flash; can be used to work with the flash
+        # from e.g. a bootloader.
+        Resource("spi_flash", 0,
+
+            # SCK is on pin 9; but doesn't have a traditional I/O buffer.
+            # Instead, we'll need to drive a clock into a USRMCLK instance.
+            # See interfaces/flash.py for more information.
+            Subsignal("sdi",  Pins("T8",  dir="o")),
+            Subsignal("sdo",  Pins("T7",  dir="i")),
+            Subsignal("cs",   PinsN("N8", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # Note: UART pins R14 and T14 are connected to JTAG pins R11 (TDI)
+        # and T11 (TMS) respectively, so the microcontroller can use either
+        # function but not both simultaneously.
+
+        # UART connected to the debug controller; can be routed to a host via CDC-ACM.
+        Resource("uart", 0,
+            Subsignal("rx",  Pins("R14",  dir="i")),
+            Subsignal("tx",  Pins("T14",  dir="oe"), Attrs(PULLMODE="UP")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # interrupt output to send signal to microcontroller
+        Resource("int", 0, Pins("R8", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # USER button
+        Resource("button_user", 0, PinsN("M14", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
+
+        # output signal connected to PROGRAMN to trigger FPGA reconfiguration
+        Resource("self_program", 0, PinsN("T13", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+
+        # FPGA LEDs
+        *LEDResources(pins="E13 C13 B14 A15 D12 C11", attrs=Attrs(IO_TYPE="LVCMOS33"), invert=True),
+
+        # USB PHYs
+        ULPIResource("control_phy", 0,
+            data="N16 N14 P16 P15 R16 R15 T15 P14", clk="L14", clk_dir='o',
+            dir="M16", nxt="M15", stp="L15", rst="L16", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("aux_phy", 0,
+            data="J16 K15 K16 J13 J14 H13 H14 K14", clk="F16", clk_dir='o',
+            dir="H15", nxt="J15", stp="G16", rst="G15", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("target_phy", 0,
+            data="R2 R1 P2 P1 N3 N1 M2 M1", clk="T4", clk_dir='o',
+            dir="R3", nxt="T2", stp="T3", rst="R4", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # direct connection to TARGET USB D+/D-
+        Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+
+        # USB Type-C controllers and pins
+        Resource("target_type_c", 0,
+            Subsignal("scl",   Pins( "A4", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "C4", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("int",   PinsN("A3", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("fault", PinsN("D4", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("sbu1",  Pins( "A2", dir="io")),
+            Subsignal("sbu2",  Pins( "E4", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+        Resource("aux_type_c", 0,
+            Subsignal("scl",   Pins( "D16", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "E15", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("int",   PinsN("H12", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("fault", PinsN("G14", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("sbu1",  Pins( "E16", dir="io")),
+            Subsignal("sbu2",  Pins( "F15", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # power input shutoff
+        Resource("control_vbus_in_en", 0, PinsN("K13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("aux_vbus_in_en",     0, PinsN("L13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # VBUS passthrough
+        #
+        # VBUS on each of the Type-C ports can be connected to TARGET A through
+        # a bidirectional switch. If any of these switches is enabled, TARGET A
+        # is considered an output. An additional switch can be enabled to pass
+        # VBUS through to another port in addition to TARGET A.
+        #
+        # The TARGET C switch is enabled by default, even when Cynthion is
+        # powered off, enabling VBUS passthrough from TARGET C to TARGET A.
+
+        Resource("target_c_vbus_en",   0, PinsN("K5", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+        Resource("control_vbus_en",    0, Pins("L1", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("aux_vbus_en",        0, Pins("L2", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_a_discharge", 0, Pins("K4", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # voltage and current monitor
+        Resource("power_monitor", 0,
+            Subsignal("scl",   Pins( "C6", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "D6", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("pwrdn", PinsN("C7", dir="o" )),
+            Subsignal("slow",  Pins( "D5", dir="io")),
+            Subsignal("gpio",  Pins( "D7", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")
+        ),
+
+        # HyperRAM
+        Resource("ram", 0,
+            Subsignal("clk",   DiffPairs("C3", "D3", dir="o"), Attrs(IO_TYPE="LVCMOS33D")),
+            Subsignal("dq",    Pins("F2 B1 C2 E1 E3 E2 F3 G4", dir="io")),
+            Subsignal("rwds",  Pins( "D1", dir="io")),
+            Subsignal("cs",    PinsN("B2", dir="o")),
+            Subsignal("reset", PinsN("C1", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")
+        ),
+
+        # User I/O connections.
+        Resource("user_pmod", 0, Pins("C9 B9 D11 C12 C8 D8 D9 C10", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_pmod", 1, Pins("B4 B5 B6 B7 C5 A5 A6 A7", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_mezzanine", 0,
+                Pins("B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11", dir="io"),
+                Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+    ]
+
+    connectors = [
+        Connector("pmod", 0, "C9 C8 D11 C12 - - B8 D8 D9 C10 - -"), # PMOD A
+        Connector("pmod", 1, "B4 B5 B6 B7 - - C5 A5 A6 A7 - -"), # PMOD B
+        Connector("mezzanine", 0,
+            "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),
+    ]
+
+    def toolchain_prepare(self, fragment, name, **kwargs):
+        overrides = {
+            'ecppack_opts': '--compress --freq 38.8'
+        }
+
+        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/host/cynthion/gateware/platform/cynthion_r1_0.py
+++ b/host/cynthion/gateware/platform/cynthion_r1_0.py
@@ -1,0 +1,204 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from amaranth.build import *
+from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
+from amaranth_boards.resources import *
+
+from luna.gateware.platform.core import LUNAApolloPlatform
+from luna.gateware.architecture.car import LunaECP5DomainGenerator
+
+__all__ = ["CynthionPlatformRev1D0"]
+
+class CynthionPlatformRev1D0(LUNAApolloPlatform, LatticeECP5Platform):
+    """ Board description for Cynthion r1.0 """
+
+    name        = "Cynthion r1.0"
+
+    device      = "LFE5U-12F"
+    package     = "BG256"
+    speed       = os.getenv("ECP5_SPEED_GRADE", "8")
+
+    default_clk = "clk_60MHz"
+
+    # Provide the type that'll be used to create our clock domains.
+    clock_domain_generator = LunaECP5DomainGenerator
+
+    # By default, assume we'll be connecting via our target PHY.
+    default_usb_connection = "target_phy"
+
+    #
+    # Default clock frequencies for each of our clock domains.
+    #
+    # Different revisions have different FPGA speed grades, and thus the
+    # default frequencies will vary.
+    #
+    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
+        "fast": 240,
+        "sync": 120,
+        "usb":  60
+    }
+
+    #
+    # Preferred DRAM bus I/O (de)-skewing constants.
+    #
+    ram_timings = dict(
+        # Set max skew to meet IO setup times
+        # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
+        clock_skew = 127
+    )
+
+    # Provides any platform-specific ULPI registers necessary.
+    # This is the spot to put any platform-specific vendor registers that need
+    # to be written.
+    ulpi_extra_registers = {
+        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
+    }
+
+    #
+    # I/O resources.
+    #
+    resources   = [
+
+        # Primary, discrete 60MHz oscillator.
+        Resource("clk_60MHz", 0, Pins("A8", dir="i"),
+            Clock(60e6), Attrs(IO_TYPE="LVCMOS33")),
+
+        # Connection to our SPI flash; can be used to work with the flash
+        # from e.g. a bootloader.
+        Resource("spi_flash", 0,
+
+            # SCK is on pin 9; but doesn't have a traditional I/O buffer.
+            # Instead, we'll need to drive a clock into a USRMCLK instance.
+            # See interfaces/flash.py for more information.
+            Subsignal("sdi",  Pins("T8",  dir="o")),
+            Subsignal("sdo",  Pins("T7",  dir="i")),
+            Subsignal("cs",   PinsN("N8", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # Note: UART pins R14 and T14 are connected to JTAG pins R11 (TDI)
+        # and T11 (TMS) respectively, so the microcontroller can use either
+        # function but not both simultaneously.
+
+        # UART connected to the debug controller; can be routed to a host via CDC-ACM.
+        Resource("uart", 0,
+            Subsignal("rx",  Pins("R14",  dir="i")),
+            Subsignal("tx",  Pins("T14",  dir="oe"), Attrs(PULLMODE="UP")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # interrupt output to send signal to microcontroller
+        Resource("int", 0, Pins("R8", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # USER button
+        Resource("button_user", 0, PinsN("M14", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
+
+        # output signal connected to PROGRAMN to trigger FPGA reconfiguration
+        Resource("self_program", 0, PinsN("T13", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+
+        # FPGA LEDs
+        *LEDResources(pins="E13 C13 B14 A15 D12 C11", attrs=Attrs(IO_TYPE="LVCMOS33"), invert=True),
+
+        # USB PHYs
+        ULPIResource("control_phy", 0,
+            data="N16 N14 P16 P15 R16 R15 T15 P14", clk="L14", clk_dir='o',
+            dir="M16", nxt="M15", stp="L15", rst="L16", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("aux_phy", 0,
+            data="J16 K15 K16 J13 J14 H13 H14 K14", clk="F16", clk_dir='o',
+            dir="H15", nxt="J15", stp="G16", rst="G15", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("target_phy", 0,
+            data="R2 R1 P2 P1 N3 N1 M2 M1", clk="T4", clk_dir='o',
+            dir="R3", nxt="T2", stp="T3", rst="R4", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # direct connection to TARGET USB D+/D-
+        Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+
+        # USB Type-C controllers and pins
+        Resource("target_type_c", 0,
+            Subsignal("scl",   Pins( "A4", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "C4", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("int",   PinsN("A3", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("fault", PinsN("D4", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("sbu1",  Pins( "A2", dir="io")),
+            Subsignal("sbu2",  Pins( "E4", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+        Resource("aux_type_c", 0,
+            Subsignal("scl",   Pins( "D16", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "E15", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("int",   PinsN("H12", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("fault", PinsN("G14", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("sbu1",  Pins( "E16", dir="io")),
+            Subsignal("sbu2",  Pins( "F15", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # power input shutoff
+        Resource("control_vbus_in_en", 0, PinsN("K13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("aux_vbus_in_en",     0, PinsN("L13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # VBUS passthrough
+        #
+        # VBUS on each of the Type-C ports can be connected to TARGET A through
+        # a bidirectional switch. If any of these switches is enabled, TARGET A
+        # is considered an output. An additional switch can be enabled to pass
+        # VBUS through to another port in addition to TARGET A.
+        #
+        # The TARGET C switch is enabled by default, even when Cynthion is
+        # powered off, enabling VBUS passthrough from TARGET C to TARGET A.
+
+        Resource("target_c_vbus_en",   0, PinsN("K5", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+        Resource("control_vbus_en",    0, Pins("L1", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("aux_vbus_en",        0, Pins("L2", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_a_discharge", 0, Pins("K4", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # voltage and current monitor
+        Resource("power_monitor", 0,
+            Subsignal("scl",   Pins( "C6", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "D6", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("pwrdn", PinsN("C7", dir="o" )),
+            Subsignal("slow",  Pins( "D5", dir="io")),
+            Subsignal("gpio",  Pins( "D7", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")
+        ),
+
+        # HyperRAM
+        Resource("ram", 0,
+            Subsignal("clk",   DiffPairs("C3", "D3", dir="o"), Attrs(IO_TYPE="LVCMOS33D")),
+            Subsignal("dq",    Pins("F2 B1 C2 E1 E3 E2 F3 G4", dir="io")),
+            Subsignal("rwds",  Pins( "D1", dir="io")),
+            Subsignal("cs",    PinsN("B2", dir="o")),
+            Subsignal("reset", PinsN("C1", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")
+        ),
+
+        # User I/O connections.
+        Resource("user_pmod", 0, Pins("C9 B9 D11 C12 C8 D8 D9 C10", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_pmod", 1, Pins("B4 B5 B6 B7 C5 A5 A6 A7", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_mezzanine", 0,
+                Pins("B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11", dir="io"),
+                Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+    ]
+
+    connectors = [
+        Connector("pmod", 0, "C9 C8 D11 C12 - - B8 D8 D9 C10 - -"), # PMOD A
+        Connector("pmod", 1, "B4 B5 B6 B7 - - C5 A5 A6 A7 - -"), # PMOD B
+        Connector("mezzanine", 0,
+            "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),
+    ]
+
+    def toolchain_prepare(self, fragment, name, **kwargs):
+        overrides = {
+            'ecppack_opts': '--compress --freq 38.8'
+        }
+
+        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/host/cynthion/gateware/platform/cynthion_r1_1.py
+++ b/host/cynthion/gateware/platform/cynthion_r1_1.py
@@ -1,0 +1,204 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from amaranth.build import *
+from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
+from amaranth_boards.resources import *
+
+from luna.gateware.platform.core import LUNAApolloPlatform
+from luna.gateware.architecture.car import LunaECP5DomainGenerator
+
+__all__ = ["CynthionPlatformRev1D1"]
+
+class CynthionPlatformRev1D1(LUNAApolloPlatform, LatticeECP5Platform):
+    """ Board description for Cynthion r1.1 """
+
+    name        = "Cynthion r1.1"
+
+    device      = "LFE5U-12F"
+    package     = "BG256"
+    speed       = os.getenv("ECP5_SPEED_GRADE", "8")
+
+    default_clk = "clk_60MHz"
+
+    # Provide the type that'll be used to create our clock domains.
+    clock_domain_generator = LunaECP5DomainGenerator
+
+    # By default, assume we'll be connecting via our target PHY.
+    default_usb_connection = "target_phy"
+
+    #
+    # Default clock frequencies for each of our clock domains.
+    #
+    # Different revisions have different FPGA speed grades, and thus the
+    # default frequencies will vary.
+    #
+    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
+        "fast": 240,
+        "sync": 120,
+        "usb":  60
+    }
+
+    #
+    # Preferred DRAM bus I/O (de)-skewing constants.
+    #
+    ram_timings = dict(
+        # Set max skew to meet IO setup times
+        # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
+        clock_skew = 127
+    )
+
+    # Provides any platform-specific ULPI registers necessary.
+    # This is the spot to put any platform-specific vendor registers that need
+    # to be written.
+    ulpi_extra_registers = {
+        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
+    }
+
+    #
+    # I/O resources.
+    #
+    resources   = [
+
+        # Primary, discrete 60MHz oscillator.
+        Resource("clk_60MHz", 0, Pins("A8", dir="i"),
+            Clock(60e6), Attrs(IO_TYPE="LVCMOS33")),
+
+        # Connection to our SPI flash; can be used to work with the flash
+        # from e.g. a bootloader.
+        Resource("spi_flash", 0,
+
+            # SCK is on pin 9; but doesn't have a traditional I/O buffer.
+            # Instead, we'll need to drive a clock into a USRMCLK instance.
+            # See interfaces/flash.py for more information.
+            Subsignal("sdi",  Pins("T8",  dir="o")),
+            Subsignal("sdo",  Pins("T7",  dir="i")),
+            Subsignal("cs",   PinsN("N8", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # Note: UART pins R14 and T14 are connected to JTAG pins R11 (TDI)
+        # and T11 (TMS) respectively, so the microcontroller can use either
+        # function but not both simultaneously.
+
+        # UART connected to the debug controller; can be routed to a host via CDC-ACM.
+        Resource("uart", 0,
+            Subsignal("rx",  Pins("R14",  dir="i")),
+            Subsignal("tx",  Pins("T14",  dir="oe"), Attrs(PULLMODE="UP")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # interrupt output to send signal to microcontroller
+        Resource("int", 0, Pins("T6", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # USER button
+        Resource("button_user", 0, PinsN("M14", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
+
+        # output signal connected to PROGRAMN to trigger FPGA reconfiguration
+        Resource("self_program", 0, PinsN("T13", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+
+        # FPGA LEDs
+        *LEDResources(pins="E13 C13 B14 A15 D12 C11", attrs=Attrs(IO_TYPE="LVCMOS33"), invert=True),
+
+        # USB PHYs
+        ULPIResource("control_phy", 0,
+            data="N16 N14 P16 P15 R16 R15 T15 P14", clk="L14", clk_dir='o',
+            dir="M16", nxt="M15", stp="L15", rst="L16", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("aux_phy", 0,
+            data="J16 K15 K16 J13 J14 H13 H14 K14", clk="F16", clk_dir='o',
+            dir="H15", nxt="J15", stp="G16", rst="G15", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("target_phy", 0,
+            data="R2 R1 P2 P1 N3 N1 M2 M1", clk="T4", clk_dir='o',
+            dir="R3", nxt="T2", stp="T3", rst="R4", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # direct connection to TARGET USB D+/D-
+        Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+
+        # USB Type-C controllers and pins
+        Resource("target_type_c", 0,
+            Subsignal("scl",   Pins( "A4", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "C4", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("int",   PinsN("A3", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("fault", PinsN("D4", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("sbu1",  Pins( "A2", dir="io")),
+            Subsignal("sbu2",  Pins( "E4", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+        Resource("aux_type_c", 0,
+            Subsignal("scl",   Pins( "D16", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "E15", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("int",   PinsN("H12", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("fault", PinsN("G14", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("sbu1",  Pins( "E16", dir="io")),
+            Subsignal("sbu2",  Pins( "F15", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # power input shutoff
+        Resource("control_vbus_in_en", 0, PinsN("K13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("aux_vbus_in_en",     0, PinsN("L13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # VBUS passthrough
+        #
+        # VBUS on each of the Type-C ports can be connected to TARGET A through
+        # a bidirectional switch. If any of these switches is enabled, TARGET A
+        # is considered an output. An additional switch can be enabled to pass
+        # VBUS through to another port in addition to TARGET A.
+        #
+        # The TARGET C switch is enabled by default, even when Cynthion is
+        # powered off, enabling VBUS passthrough from TARGET C to TARGET A.
+
+        Resource("target_c_vbus_en",   0, PinsN("K5", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+        Resource("control_vbus_en",    0, Pins("L1", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("aux_vbus_en",        0, Pins("L2", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_a_discharge", 0, Pins("K4", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # voltage and current monitor
+        Resource("power_monitor", 0,
+            Subsignal("scl",   Pins( "D7", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "C7", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("pwrdn", PinsN("D5", dir="o" )),
+            Subsignal("slow",  Pins( "C6", dir="io")),
+            Subsignal("gpio",  Pins( "D6", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")
+        ),
+
+        # HyperRAM
+        Resource("ram", 0,
+            Subsignal("clk",   DiffPairs("C3", "D3", dir="o"), Attrs(IO_TYPE="LVCMOS33D")),
+            Subsignal("dq",    Pins("F2 B1 C2 E1 E3 E2 F3 G4", dir="io")),
+            Subsignal("rwds",  Pins( "D1", dir="io")),
+            Subsignal("cs",    PinsN("B2", dir="o")),
+            Subsignal("reset", PinsN("C1", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")
+        ),
+
+        # User I/O connections.
+        Resource("user_pmod", 0, Pins("C9 B9 D11 C12 C8 D8 D9 C10", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_pmod", 1, Pins("B4 B5 B6 B7 C5 A5 A6 A7", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_mezzanine", 0,
+                Pins("B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11", dir="io"),
+                Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+    ]
+
+    connectors = [
+        Connector("pmod", 0, "C9 C8 D11 C12 - - B8 D8 D9 C10 - -"), # PMOD A
+        Connector("pmod", 1, "B4 B5 B6 B7 - - C5 A5 A6 A7 - -"), # PMOD B
+        Connector("mezzanine", 0,
+            "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),
+    ]
+
+    def toolchain_prepare(self, fragment, name, **kwargs):
+        overrides = {
+            'ecppack_opts': '--compress --freq 38.8'
+        }
+
+        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/host/cynthion/gateware/platform/cynthion_r1_2.py
+++ b/host/cynthion/gateware/platform/cynthion_r1_2.py
@@ -1,0 +1,216 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from amaranth.build import *
+from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
+from amaranth_boards.resources import *
+
+from luna.gateware.platform.core import LUNAApolloPlatform
+from luna.gateware.architecture.car import LunaECP5DomainGenerator
+
+__all__ = ["CynthionPlatformRev1D2"]
+
+class CynthionPlatformRev1D2(LUNAApolloPlatform, LatticeECP5Platform):
+    """ Board description for Cynthion r1.2 """
+
+    name        = "Cynthion r1.2"
+
+    device      = "LFE5U-12F"
+    package     = "BG256"
+    speed       = os.getenv("ECP5_SPEED_GRADE", "8")
+
+    default_clk = "clk_60MHz"
+
+    # Provide the type that'll be used to create our clock domains.
+    clock_domain_generator = LunaECP5DomainGenerator
+
+    # By default, assume we'll be connecting via our target PHY.
+    default_usb_connection = "target_phy"
+
+    #
+    # Default clock frequencies for each of our clock domains.
+    #
+    # Different revisions have different FPGA speed grades, and thus the
+    # default frequencies will vary.
+    #
+    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
+        "fast": 240,
+        "sync": 120,
+        "usb":  60
+    }
+
+    #
+    # Preferred DRAM bus I/O (de)-skewing constants.
+    #
+    ram_timings = dict(
+        # Set max skew to meet IO setup times
+        # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
+        clock_skew = 127
+    )
+
+    # Provides any platform-specific ULPI registers necessary.
+    # This is the spot to put any platform-specific vendor registers that need
+    # to be written.
+    ulpi_extra_registers = {
+        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
+    }
+
+    #
+    # I/O resources.
+    #
+    resources   = [
+
+        # Pseudo-supply pins
+        #
+        # These I/O pins are connected to VCCIO or GND and are intended to be
+        # driven as outputs in order to source or sink additional supply
+        # current.
+        Resource("pseudo_vccio", 0,
+                 Pins("E6 E7 D10 E10 E11 F12 J12 K12 L12 N13 P13 M11 P11 P12 L4 M4 R5 M5 N5 P4 M6 F5 G5 H5 H4 J4 J5 J3 J1 J2 R6", dir="o"),
+                 Attrs(IO_TYPE="LVCMOS33")),
+        Resource("pseudo_gnd", 0,
+                 Pins("E5 E8 E9 E12 F13 M13 M12 N12 N11 L5 L3 M3 N6 P5 P6 F4 G2 G3 H3 H2", dir="o"),
+                 Attrs(IO_TYPE="LVCMOS33")),
+
+        # Primary, discrete 60MHz oscillator.
+        Resource("clk_60MHz", 0, Pins("A8", dir="i"),
+            Clock(60e6), Attrs(IO_TYPE="LVCMOS33")),
+
+        # Connection to our SPI flash; can be used to work with the flash
+        # from e.g. a bootloader.
+        Resource("spi_flash", 0,
+
+            # SCK is on pin 9; but doesn't have a traditional I/O buffer.
+            # Instead, we'll need to drive a clock into a USRMCLK instance.
+            # See interfaces/flash.py for more information.
+            Subsignal("sdi",  Pins("T8",  dir="o")),
+            Subsignal("sdo",  Pins("T7",  dir="i")),
+            Subsignal("cs",   PinsN("N8", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # Note: UART pins R14 and T14 are connected to JTAG pins R11 (TDI)
+        # and T11 (TMS) respectively, so the microcontroller can use either
+        # function but not both simultaneously.
+
+        # UART connected to the debug controller; can be routed to a host via CDC-ACM.
+        Resource("uart", 0,
+            Subsignal("rx",  Pins("R14",  dir="i")),
+            Subsignal("tx",  Pins("T14",  dir="oe"), Attrs(PULLMODE="UP")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # interrupt output to send signal to microcontroller
+        Resource("int", 0, Pins("T6", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # USER button
+        Resource("button_user", 0, PinsN("M14", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
+
+        # output signal connected to PROGRAMN to trigger FPGA reconfiguration
+        Resource("self_program", 0, PinsN("T13", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+
+        # FPGA LEDs
+        *LEDResources(pins="E13 C13 B14 A15 D12 C11", attrs=Attrs(IO_TYPE="LVCMOS33"), invert=True),
+
+        # USB PHYs
+        ULPIResource("control_phy", 0,
+            data="N16 N14 P16 P15 R16 R15 T15 P14", clk="L14", clk_dir='o',
+            dir="M16", nxt="M15", stp="L15", rst="L16", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("aux_phy", 0,
+            data="F16 G15 G16 H15 J15 J16 K15 K16", clk="D16", clk_dir='o',
+            dir="E16", nxt="F15", stp="E15", rst="J13", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+        ULPIResource("target_phy", 0,
+            data="R2 R1 P2 P1 N3 N1 M2 M1", clk="T4", clk_dir='o',
+            dir="R3", nxt="T2", stp="T3", rst="R4", rst_invert=True,
+            attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+
+        # direct connection to TARGET USB D+/D-
+        Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+
+        # USB Type-C controllers and pins
+        Resource("target_type_c", 0,
+            Subsignal("scl",   Pins( "A4", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "C4", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("int",   PinsN("A3", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("fault", PinsN("D4", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("sbu1",  Pins( "A2", dir="io")),
+            Subsignal("sbu2",  Pins( "E4", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+        Resource("aux_type_c", 0,
+            Subsignal("scl",   Pins( "H12", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "G14", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("int",   PinsN("H14", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("fault", PinsN("J14", dir="i" ), Attrs(PULLMODE="UP")),
+            Subsignal("sbu1",  Pins( "H13", dir="io")),
+            Subsignal("sbu2",  Pins( "K14", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # power input shutoff
+        Resource("control_vbus_in_en", 0, PinsN("K13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("aux_vbus_in_en",     0, PinsN("L13", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # VBUS passthrough
+        #
+        # VBUS on each of the Type-C ports can be connected to TARGET A through
+        # a bidirectional switch. If any of these switches is enabled, TARGET A
+        # is considered an output. An additional switch can be enabled to pass
+        # VBUS through to another port in addition to TARGET A.
+        #
+        # The TARGET C switch is enabled by default, even when Cynthion is
+        # powered off, enabling VBUS passthrough from TARGET C to TARGET A.
+
+        Resource("target_c_vbus_en",   0, PinsN("K5", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+        Resource("control_vbus_en",    0, Pins("L1", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("aux_vbus_en",        0, Pins("L2", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("target_a_discharge", 0, Pins("K4", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # voltage and current monitor
+        Resource("power_monitor", 0,
+            Subsignal("scl",   Pins( "D7", dir="o" ), Attrs(PULLMODE="NONE")),
+            Subsignal("sda",   Pins( "C7", dir="io"), Attrs(PULLMODE="NONE")),
+            Subsignal("pwrdn", PinsN("D5", dir="o" )),
+            Subsignal("slow",  Pins( "C6", dir="io")),
+            Subsignal("gpio",  Pins( "D6", dir="io")),
+            Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")
+        ),
+
+        # HyperRAM
+        Resource("ram", 0,
+            Subsignal("clk",   DiffPairs("C3", "D3", dir="o"), Attrs(IO_TYPE="LVCMOS33D")),
+            Subsignal("dq",    Pins("F2 B1 C2 E1 E3 E2 F3 G4", dir="io")),
+            Subsignal("rwds",  Pins( "D1", dir="io")),
+            Subsignal("cs",    PinsN("B2", dir="o")),
+            Subsignal("reset", PinsN("C1", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")
+        ),
+
+        # User I/O connections.
+        Resource("user_pmod", 0, Pins("C9 B9 D11 C12 C8 D8 D9 C10", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_pmod", 1, Pins("B4 B5 B6 B7 C5 A5 A6 A7", dir="io"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("user_mezzanine", 0,
+                Pins("B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11", dir="io"),
+                Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")),
+    ]
+
+    connectors = [
+        Connector("pmod", 0, "C9 C8 D11 C12 - - B8 D8 D9 C10 - -"), # PMOD A
+        Connector("pmod", 1, "B4 B5 B6 B7 - - C5 A5 A6 A7 - -"), # PMOD B
+        Connector("mezzanine", 0,
+            "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),
+    ]
+
+    def toolchain_prepare(self, fragment, name, **kwargs):
+        overrides = {
+            'ecppack_opts': '--compress --freq 38.8'
+        }
+
+        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)


### PR DESCRIPTION
This PR adds the Amaranth/LUNA platform definitions for Cynthion gateware development, placing them in the `cynthion.gateware.platforms` module.

Also provides an `APOLLO_PLATFORMS` lookup table which will be used to support platform autodetection by a new version of the `get_appropriate_platform` function in the LUNA framework.