### PR TITLE
host: use moondancer branch for pygreat dependency until next libgreat release

### DIFF
--- a/host/pyproject.toml
+++ b/host/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "tqdm",
     "tabulate",
     "prompt_toolkit",
-    "pygreat",
+    "pygreat @ git+https://github.com/antoinevg/libgreat.git@antoinevg/moondancer#subdirectory=host",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Cynthion's Python host module currently depends on the new `usb1` backend for `pygreat`.

This PR sets the dependency to use the `antoinevg/moondancer` branch of `libgreat.git` which includes this backend.

This commit can be reverted once the following PR has been merged and a new release pushed:

* https://github.com/greatscottgadgets/libgreat/pull/33

The tracking issue is:

* 