### PR TITLE
Add Cynthion base class and support for platform-specific fragments

### DIFF
--- a/cynthion/python/src/gateware/platform/core.py
+++ b/cynthion/python/src/gateware/platform/core.py
@@ -1,0 +1,99 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2020-2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+from amaranth.build import *
+from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
+from amaranth_boards.resources import *
+
+from luna.gateware.platform.core import LUNAApolloPlatform
+from luna.gateware.architecture.car import LunaECP5DomainGenerator
+
+__all__ = ["CynthionPlatform"]
+
+class CynthionPlatform(LUNAApolloPlatform, LatticeECP5Platform):
+    """ Board description for Cynthion """
+
+    default_clk = "clk_60MHz"
+
+    # Provide the type that'll be used to create our clock domains.
+    clock_domain_generator = LunaECP5DomainGenerator
+
+    #
+    # Default clock frequencies for each of our clock domains.
+    #
+    # Different revisions have different FPGA speed grades, and thus the
+    # default frequencies will vary.
+    #
+    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
+        "fast": 240,
+        "sync": 120,
+        "usb":  60
+    }
+
+    #
+    # Preferred DRAM bus I/O (de)-skewing constants.
+    #
+    ram_timings = dict(
+        # Set max skew to meet IO setup times
+        # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
+        clock_skew = 127
+    )
+
+    # Provides any platform-specific ULPI registers necessary.
+    # This is the spot to put any platform-specific vendor registers that need
+    # to be written.
+    ulpi_extra_registers = {
+        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
+    }
+
+    def toolchain_prepare(self, fragment, name, **kwargs):
+        overrides = {
+            'ecppack_opts': '--compress --freq 38.8'
+        }
+
+        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)
+
+    def toolchain_program(self, products, name):
+        """ Programs the relevant LUNA board via its sideband connection. """
+
+        from apollo_fpga import ApolloDebugger
+        from apollo_fpga.ecp5 import ECP5_JTAGProgrammer
+
+        # Create our connection to the debug module.
+        debugger = ApolloDebugger()
+
+        # Grab our generated bitstream, and upload it to the FPGA.
+        bitstream =  products.get("{}.bit".format(name))
+        with debugger.jtag as jtag:
+            programmer = ECP5_JTAGProgrammer(jtag)
+            programmer.configure(bitstream)
+
+        # Let the LUNA gateware take over in devices with shared USB port
+        debugger.honor_fpga_adv()
+
+
+    def toolchain_flash(self, products, name="top"):
+        """ Programs the LUNA board's flash via its sideband connection. """
+
+        from apollo_fpga import ApolloDebugger
+        from apollo_fpga.ecp5 import ECP5_JTAGProgrammer
+
+        # Create our connection to the debug module.
+        debugger = ApolloDebugger()
+        self._ensure_unconfigured(debugger)
+
+        # Grab our generated bitstream, and upload it to the .
+        bitstream =  products.get("{}.bit".format(name))
+        with debugger.jtag as jtag:
+            programmer = ECP5_JTAGProgrammer(jtag)
+            programmer.flash(bitstream)
+
+        debugger.soft_reset()
+
+        # Let the LUNA gateware take over in devices with shared USB port
+        debugger.honor_fpga_adv()

--- a/cynthion/python/src/gateware/platform/core.py
+++ b/cynthion/python/src/gateware/platform/core.py
@@ -103,14 +103,14 @@ class CynthionPlatform(LUNAApolloPlatform, LatticeECP5Platform):
     def pseudo_power_supply_fragment(self):
         """ Fragment to assign fixed values to the pseudo power supply pins """
         m = Module()
-        pseudo_vccio = self.request_optional("pseudo_vccio", default=None)
-        pseudo_gnd   = self.request_optional("pseudo_gnd", default=None)
-        if pseudo_vccio is not None:
-            m.d.comb += pseudo_vccio.o.eq(-1)
-        if pseudo_gnd is not None:
-            m.d.comb += pseudo_gnd.o.eq(0)
+        if ("pseudo_vccio", 0) in self.resources:
+            m.d.comb += self.request("pseudo_vccio").o.eq(-1)
+        if ("pseudo_gnd", 0) in self.resources:
+            m.d.comb += self.request("pseudo_gnd").o.eq(0)
         return m
 
+    # This list can be safely overriden in child classes.
+    # Fragments defined in this class are always added.
     append_fragments = [ pseudo_power_supply_fragment ]
 
     def prepare(self, elaboratable, name="top", **kwargs):

--- a/cynthion/python/src/gateware/platform/cynthion_r0_1.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_1.py
@@ -7,10 +7,8 @@
 import os
 
 from amaranth.build import Resource, Subsignal, Pins, PinsN, Attrs, Clock, DiffPairs, Connector
-from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 
-from luna.gateware.platform.core import LUNAApolloPlatform
-from luna.gateware.architecture.car import LunaECP5DomainGenerator
+from cynthion.gateware.platform.core import CynthionPlatform
 
 __all__ = ["CynthionPlatformRev0D1"]
 
@@ -35,7 +33,7 @@ def ULPIResource(name, data_sites, clk_site, dir_site, nxt_site, stp_site, reset
     )
 
 
-class CynthionPlatformRev0D1(LUNAApolloPlatform, LatticeECP5Platform):
+class CynthionPlatformRev0D1(CynthionPlatform):
     """ Board description for the pre-release r0.1 revision of Cynthion. """
 
     name        = "Cynthion r0.1"
@@ -50,25 +48,8 @@ class CynthionPlatformRev0D1(LUNAApolloPlatform, LatticeECP5Platform):
     # We'll assume speed grade 8 unless the user overrides it on the command line.
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
-    default_clk = "clk_60MHz"
-
-    # Provide the type that'll be used to create our clock domains.
-    clock_domain_generator = LunaECP5DomainGenerator
-
     # By default, assume we'll be connecting via our target PHY.
     default_usb_connection = "target_phy"
-
-    #
-    # Default clock frequencies for each of our clock domains.
-    #
-    # Different revisions have different FPGA speed grades, and thus the
-    # default frequencies will vary.
-    #
-    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
-        "fast": 240,
-        "sync": 120,
-        "usb":  60
-    }
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.
@@ -76,15 +57,6 @@ class CynthionPlatformRev0D1(LUNAApolloPlatform, LatticeECP5Platform):
     ram_timings = dict(
         clock_skew = 64
     )
-
-    # Provides any platform-specific ULPI registers necessary.
-    # This is the spot to put any platform-specific vendor registers that need
-    # to be written.
-    ulpi_extra_registers = {
-        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
-    }
-
-
 
     #
     # I/O resources.
@@ -203,10 +175,3 @@ class CynthionPlatformRev0D1(LUNAApolloPlatform, LatticeECP5Platform):
         """)
 
     ]
-
-    def toolchain_prepare(self, fragment, name, **kwargs):
-        overrides = {
-            'ecppack_opts': '--compress --idcode {} --freq 38.8'.format(0x21111043)
-        }
-
-        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/cynthion/python/src/gateware/platform/cynthion_r0_2.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_2.py
@@ -7,11 +7,9 @@
 import os
 
 from amaranth.build import *
-from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 from amaranth_boards.resources import *
 
-from luna.gateware.platform.core import LUNAApolloPlatform
-from luna.gateware.architecture.car import LunaECP5DomainGenerator
+from cynthion.gateware.platform.core import CynthionPlatform
 
 __all__ = ["CynthionPlatformRev0D2"]
 
@@ -21,7 +19,7 @@ __all__ = ["CynthionPlatformRev0D2"]
 # This is supported by a PHY feature that allows you to swap pins 13 + 14.
 #
 
-class CynthionPlatformRev0D2(LUNAApolloPlatform, LatticeECP5Platform):
+class CynthionPlatformRev0D2(CynthionPlatform):
     """ Board description for the pre-release r0.2 revision of Cynthion. """
 
     name        = "Cynthion r0.2"
@@ -30,25 +28,8 @@ class CynthionPlatformRev0D2(LUNAApolloPlatform, LatticeECP5Platform):
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
-    default_clk = "clk_60MHz"
-
-    # Provide the type that'll be used to create our clock domains.
-    clock_domain_generator = LunaECP5DomainGenerator
-
     # By default, assume we'll be connecting via our target PHY.
     default_usb_connection = "target_phy"
-
-    #
-    # Default clock frequencies for each of our clock domains.
-    #
-    # Different revisions have different FPGA speed grades, and thus the
-    # default frequencies will vary.
-    #
-    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
-        "fast": 240,
-        "sync": 120,
-        "usb":  60
-    }
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.
@@ -56,14 +37,6 @@ class CynthionPlatformRev0D2(LUNAApolloPlatform, LatticeECP5Platform):
     ram_timings = dict(
         clock_skew = 64
     )
-
-    # Provides any platform-specific ULPI registers necessary.
-    # This is the spot to put any platform-specific vendor registers that need
-    # to be written.
-    ulpi_extra_registers = {
-        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
-    }
-
 
     #
     # I/O resources.
@@ -162,11 +135,3 @@ class CynthionPlatformRev0D2(LUNAApolloPlatform, LatticeECP5Platform):
             A4  -  A3
         """)
     ]
-
-    def toolchain_prepare(self, fragment, name, **kwargs):
-        overrides = {
-            'ecppack_opts': '--compress --freq 38.8'
-        }
-
-        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)
-

--- a/cynthion/python/src/gateware/platform/cynthion_r0_3.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_3.py
@@ -7,11 +7,9 @@
 import os
 
 from amaranth.build import *
-from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 from amaranth_boards.resources import *
 
-from luna.gateware.platform.core import LUNAApolloPlatform
-from luna.gateware.architecture.car import LunaECP5DomainGenerator
+from cynthion.gateware.platform.core import CynthionPlatform
 
 __all__ = ["CynthionPlatformRev0D3"]
 
@@ -21,7 +19,7 @@ __all__ = ["CynthionPlatformRev0D3"]
 # This is supported by a PHY feature that allows you to swap pins 13 + 14.
 #
 
-class CynthionPlatformRev0D3(LUNAApolloPlatform, LatticeECP5Platform):
+class CynthionPlatformRev0D3(CynthionPlatform):
     """ Board description for the pre-release r0.3 revision of Cynthion. """
 
     name        = "Cynthion r0.3"
@@ -30,25 +28,8 @@ class CynthionPlatformRev0D3(LUNAApolloPlatform, LatticeECP5Platform):
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
-    default_clk = "clk_60MHz"
-
-    # Provide the type that'll be used to create our clock domains.
-    clock_domain_generator = LunaECP5DomainGenerator
-
     # By default, assume we'll be connecting via our target PHY.
     default_usb_connection = "target_phy"
-
-    #
-    # Default clock frequencies for each of our clock domains.
-    #
-    # Different revisions have different FPGA speed grades, and thus the
-    # default frequencies will vary.
-    #
-    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
-        "fast": 240,
-        "sync": 120,
-        "usb":  60
-    }
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.
@@ -56,14 +37,6 @@ class CynthionPlatformRev0D3(LUNAApolloPlatform, LatticeECP5Platform):
     ram_timings = dict(
         clock_skew = 16
     )
-
-    # Provides any platform-specific ULPI registers necessary.
-    # This is the spot to put any platform-specific vendor registers that need
-    # to be written.
-    ulpi_extra_registers = {
-        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
-    }
-
 
     #
     # I/O resources.
@@ -174,10 +147,3 @@ class CynthionPlatformRev0D3(LUNAApolloPlatform, LatticeECP5Platform):
         Connector("pmod", 0, "A3 A4 A5 A6 - - C6 B6 C7 B7 - -"), # Pmod A
         Connector("pmod", 1, "M5 N5 M4 N3 - - L4 L5 K4 K5 - -"), # Pmod B
     ]
-
-    def toolchain_prepare(self, fragment, name, **kwargs):
-        overrides = {
-            'ecppack_opts': '--compress --freq 38.8'
-        }
-
-        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/cynthion/python/src/gateware/platform/cynthion_r0_4.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_4.py
@@ -7,11 +7,9 @@
 import os
 
 from amaranth.build import *
-from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 from amaranth_boards.resources import *
 
-from luna.gateware.platform.core import LUNAApolloPlatform
-from luna.gateware.architecture.car import LunaECP5DomainGenerator
+from cynthion.gateware.platform.core import CynthionPlatform
 
 __all__ = ["CynthionPlatformRev0D4"]
 
@@ -21,7 +19,7 @@ __all__ = ["CynthionPlatformRev0D4"]
 # This is supported by a PHY feature that allows you to swap pins 13 + 14.
 #
 
-class CynthionPlatformRev0D4(LUNAApolloPlatform, LatticeECP5Platform):
+class CynthionPlatformRev0D4(CynthionPlatform):
     """ Board description for the pre-release r0.4 revision of Cynthion. """
 
     name        = "Cynthion r0.4"
@@ -30,25 +28,8 @@ class CynthionPlatformRev0D4(LUNAApolloPlatform, LatticeECP5Platform):
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
-    default_clk = "clk_60MHz"
-
-    # Provide the type that'll be used to create our clock domains.
-    clock_domain_generator = LunaECP5DomainGenerator
-
     # By default, assume we'll be connecting via our target PHY.
     default_usb_connection = "target_phy"
-
-    #
-    # Default clock frequencies for each of our clock domains.
-    #
-    # Different revisions have different FPGA speed grades, and thus the
-    # default frequencies will vary.
-    #
-    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
-        "fast": 240,
-        "sync": 120,
-        "usb":  60
-    }
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.
@@ -58,14 +39,6 @@ class CynthionPlatformRev0D4(LUNAApolloPlatform, LatticeECP5Platform):
         # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
         clock_skew = 127
     )
-
-    # Provides any platform-specific ULPI registers necessary.
-    # This is the spot to put any platform-specific vendor registers that need
-    # to be written.
-    ulpi_extra_registers = {
-        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
-    }
-
 
     #
     # I/O resources.
@@ -176,10 +149,3 @@ class CynthionPlatformRev0D4(LUNAApolloPlatform, LatticeECP5Platform):
         Connector("pmod", 0, "A3 A4 A5 A6 - - C6 B6 C7 B7 - -"), # Pmod A
         Connector("pmod", 1, "M5 N5 M4 N3 - - L4 L5 K4 K5 - -"), # Pmod B
     ]
-
-    def toolchain_prepare(self, fragment, name, **kwargs):
-        overrides = {
-            'ecppack_opts': '--compress --freq 38.8'
-        }
-
-        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/cynthion/python/src/gateware/platform/cynthion_r0_5.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_5.py
@@ -7,11 +7,9 @@
 import os
 
 from amaranth.build import *
-from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 from amaranth_boards.resources import *
 
-from luna.gateware.platform.core import LUNAApolloPlatform
-from luna.gateware.architecture.car import LunaECP5DomainGenerator
+from cynthion.gateware.platform.core import CynthionPlatform
 
 __all__ = ["CynthionPlatformRev0D5"]
 
@@ -21,7 +19,7 @@ __all__ = ["CynthionPlatformRev0D5"]
 # This is supported by a PHY feature that allows you to swap pins 13 + 14.
 #
 
-class CynthionPlatformRev0D5(LUNAApolloPlatform, LatticeECP5Platform):
+class CynthionPlatformRev0D5(CynthionPlatform):
     """ Board description for the pre-release r0.5 revision of Cynthion. """
 
     name        = "Cynthion r0.5"
@@ -30,25 +28,8 @@ class CynthionPlatformRev0D5(LUNAApolloPlatform, LatticeECP5Platform):
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
-    default_clk = "clk_60MHz"
-
-    # Provide the type that'll be used to create our clock domains.
-    clock_domain_generator = LunaECP5DomainGenerator
-
     # By default, assume we'll be connecting via our target PHY.
     default_usb_connection = "target_phy"
-
-    #
-    # Default clock frequencies for each of our clock domains.
-    #
-    # Different revisions have different FPGA speed grades, and thus the
-    # default frequencies will vary.
-    #
-    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
-        "fast": 240,
-        "sync": 120,
-        "usb":  60
-    }
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.
@@ -58,14 +39,6 @@ class CynthionPlatformRev0D5(LUNAApolloPlatform, LatticeECP5Platform):
         # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
         clock_skew = 127
     )
-
-    # Provides any platform-specific ULPI registers necessary.
-    # This is the spot to put any platform-specific vendor registers that need
-    # to be written.
-    ulpi_extra_registers = {
-        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
-    }
-
 
     #
     # I/O resources.
@@ -176,10 +149,3 @@ class CynthionPlatformRev0D5(LUNAApolloPlatform, LatticeECP5Platform):
         Connector("pmod", 0, "A3 A4 A5 A6 - - C6 B6 C7 B7 - -"), # Pmod A
         Connector("pmod", 1, "M5 N5 M4 N3 - - L4 L5 K4 K5 - -"), # Pmod B
     ]
-
-    def toolchain_prepare(self, fragment, name, **kwargs):
-        overrides = {
-            'ecppack_opts': '--compress --freq 38.8'
-        }
-
-        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/cynthion/python/src/gateware/platform/cynthion_r0_6.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_6.py
@@ -7,15 +7,13 @@
 import os
 
 from amaranth.build import *
-from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 from amaranth_boards.resources import *
 
-from luna.gateware.platform.core import LUNAApolloPlatform
-from luna.gateware.architecture.car import LunaECP5DomainGenerator
+from cynthion.gateware.platform.core import CynthionPlatform
 
 __all__ = ["CynthionPlatformRev0D6"]
 
-class CynthionPlatformRev0D6(LUNAApolloPlatform, LatticeECP5Platform):
+class CynthionPlatformRev0D6(CynthionPlatform):
     """ Board description for Cynthion r0.6 """
 
     name        = "Cynthion r0.6"
@@ -24,25 +22,8 @@ class CynthionPlatformRev0D6(LUNAApolloPlatform, LatticeECP5Platform):
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
-    default_clk = "clk_60MHz"
-
-    # Provide the type that'll be used to create our clock domains.
-    clock_domain_generator = LunaECP5DomainGenerator
-
     # By default, assume we'll be connecting via our target PHY.
     default_usb_connection = "target_phy"
-
-    #
-    # Default clock frequencies for each of our clock domains.
-    #
-    # Different revisions have different FPGA speed grades, and thus the
-    # default frequencies will vary.
-    #
-    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
-        "fast": 240,
-        "sync": 120,
-        "usb":  60
-    }
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.
@@ -52,13 +33,6 @@ class CynthionPlatformRev0D6(LUNAApolloPlatform, LatticeECP5Platform):
         # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
         clock_skew = 127
     )
-
-    # Provides any platform-specific ULPI registers necessary.
-    # This is the spot to put any platform-specific vendor registers that need
-    # to be written.
-    ulpi_extra_registers = {
-        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
-    }
 
     #
     # I/O resources.
@@ -195,10 +169,3 @@ class CynthionPlatformRev0D6(LUNAApolloPlatform, LatticeECP5Platform):
         Connector("mezzanine", 0,
             "- - B9 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),
     ]
-
-    def toolchain_prepare(self, fragment, name, **kwargs):
-        overrides = {
-            'ecppack_opts': '--compress --freq 38.8'
-        }
-
-        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/cynthion/python/src/gateware/platform/cynthion_r0_7.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_7.py
@@ -7,15 +7,13 @@
 import os
 
 from amaranth.build import *
-from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 from amaranth_boards.resources import *
 
-from luna.gateware.platform.core import LUNAApolloPlatform
-from luna.gateware.architecture.car import LunaECP5DomainGenerator
+from cynthion.gateware.platform.core import CynthionPlatform
 
 __all__ = ["CynthionPlatformRev0D7"]
 
-class CynthionPlatformRev0D7(LUNAApolloPlatform, LatticeECP5Platform):
+class CynthionPlatformRev0D7(CynthionPlatform):
     """ Board description for Cynthion r0.7 """
 
     name        = "Cynthion r0.7"
@@ -24,25 +22,8 @@ class CynthionPlatformRev0D7(LUNAApolloPlatform, LatticeECP5Platform):
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
-    default_clk = "clk_60MHz"
-
-    # Provide the type that'll be used to create our clock domains.
-    clock_domain_generator = LunaECP5DomainGenerator
-
     # By default, assume we'll be connecting via our target PHY.
     default_usb_connection = "target_phy"
-
-    #
-    # Default clock frequencies for each of our clock domains.
-    #
-    # Different revisions have different FPGA speed grades, and thus the
-    # default frequencies will vary.
-    #
-    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
-        "fast": 240,
-        "sync": 120,
-        "usb":  60
-    }
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.
@@ -52,13 +33,6 @@ class CynthionPlatformRev0D7(LUNAApolloPlatform, LatticeECP5Platform):
         # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
         clock_skew = 127
     )
-
-    # Provides any platform-specific ULPI registers necessary.
-    # This is the spot to put any platform-specific vendor registers that need
-    # to be written.
-    ulpi_extra_registers = {
-        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
-    }
 
     #
     # I/O resources.
@@ -195,10 +169,3 @@ class CynthionPlatformRev0D7(LUNAApolloPlatform, LatticeECP5Platform):
         Connector("mezzanine", 0,
             "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),
     ]
-
-    def toolchain_prepare(self, fragment, name, **kwargs):
-        overrides = {
-            'ecppack_opts': '--compress --freq 38.8'
-        }
-
-        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/cynthion/python/src/gateware/platform/cynthion_r1_0.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_0.py
@@ -7,15 +7,13 @@
 import os
 
 from amaranth.build import *
-from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 from amaranth_boards.resources import *
 
-from luna.gateware.platform.core import LUNAApolloPlatform
-from luna.gateware.architecture.car import LunaECP5DomainGenerator
+from cynthion.gateware.platform.core import CynthionPlatform
 
 __all__ = ["CynthionPlatformRev1D0"]
 
-class CynthionPlatformRev1D0(LUNAApolloPlatform, LatticeECP5Platform):
+class CynthionPlatformRev1D0(CynthionPlatform):
     """ Board description for Cynthion r1.0 """
 
     name        = "Cynthion r1.0"
@@ -24,25 +22,8 @@ class CynthionPlatformRev1D0(LUNAApolloPlatform, LatticeECP5Platform):
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
-    default_clk = "clk_60MHz"
-
-    # Provide the type that'll be used to create our clock domains.
-    clock_domain_generator = LunaECP5DomainGenerator
-
     # By default, assume we'll be connecting via our target PHY.
     default_usb_connection = "target_phy"
-
-    #
-    # Default clock frequencies for each of our clock domains.
-    #
-    # Different revisions have different FPGA speed grades, and thus the
-    # default frequencies will vary.
-    #
-    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
-        "fast": 240,
-        "sync": 120,
-        "usb":  60
-    }
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.
@@ -52,13 +33,6 @@ class CynthionPlatformRev1D0(LUNAApolloPlatform, LatticeECP5Platform):
         # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
         clock_skew = 127
     )
-
-    # Provides any platform-specific ULPI registers necessary.
-    # This is the spot to put any platform-specific vendor registers that need
-    # to be written.
-    ulpi_extra_registers = {
-        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
-    }
 
     #
     # I/O resources.
@@ -195,10 +169,3 @@ class CynthionPlatformRev1D0(LUNAApolloPlatform, LatticeECP5Platform):
         Connector("mezzanine", 0,
             "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),
     ]
-
-    def toolchain_prepare(self, fragment, name, **kwargs):
-        overrides = {
-            'ecppack_opts': '--compress --freq 38.8'
-        }
-
-        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/cynthion/python/src/gateware/platform/cynthion_r1_1.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_1.py
@@ -7,15 +7,13 @@
 import os
 
 from amaranth.build import *
-from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 from amaranth_boards.resources import *
 
-from luna.gateware.platform.core import LUNAApolloPlatform
-from luna.gateware.architecture.car import LunaECP5DomainGenerator
+from cynthion.gateware.platform.core import CynthionPlatform
 
 __all__ = ["CynthionPlatformRev1D1"]
 
-class CynthionPlatformRev1D1(LUNAApolloPlatform, LatticeECP5Platform):
+class CynthionPlatformRev1D1(CynthionPlatform):
     """ Board description for Cynthion r1.1 """
 
     name        = "Cynthion r1.1"
@@ -24,25 +22,8 @@ class CynthionPlatformRev1D1(LUNAApolloPlatform, LatticeECP5Platform):
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
-    default_clk = "clk_60MHz"
-
-    # Provide the type that'll be used to create our clock domains.
-    clock_domain_generator = LunaECP5DomainGenerator
-
     # By default, assume we'll be connecting via our target PHY.
     default_usb_connection = "target_phy"
-
-    #
-    # Default clock frequencies for each of our clock domains.
-    #
-    # Different revisions have different FPGA speed grades, and thus the
-    # default frequencies will vary.
-    #
-    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
-        "fast": 240,
-        "sync": 120,
-        "usb":  60
-    }
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.
@@ -52,13 +33,6 @@ class CynthionPlatformRev1D1(LUNAApolloPlatform, LatticeECP5Platform):
         # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
         clock_skew = 127
     )
-
-    # Provides any platform-specific ULPI registers necessary.
-    # This is the spot to put any platform-specific vendor registers that need
-    # to be written.
-    ulpi_extra_registers = {
-        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
-    }
 
     #
     # I/O resources.
@@ -195,10 +169,3 @@ class CynthionPlatformRev1D1(LUNAApolloPlatform, LatticeECP5Platform):
         Connector("mezzanine", 0,
             "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),
     ]
-
-    def toolchain_prepare(self, fragment, name, **kwargs):
-        overrides = {
-            'ecppack_opts': '--compress --freq 38.8'
-        }
-
-        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/cynthion/python/src/gateware/platform/cynthion_r1_2.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_2.py
@@ -7,15 +7,13 @@
 import os
 
 from amaranth.build import *
-from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 from amaranth_boards.resources import *
 
-from luna.gateware.platform.core import LUNAApolloPlatform
-from luna.gateware.architecture.car import LunaECP5DomainGenerator
+from cynthion.gateware.platform.core import CynthionPlatform
 
 __all__ = ["CynthionPlatformRev1D2"]
 
-class CynthionPlatformRev1D2(LUNAApolloPlatform, LatticeECP5Platform):
+class CynthionPlatformRev1D2(CynthionPlatform):
     """ Board description for Cynthion r1.2 """
 
     name        = "Cynthion r1.2"
@@ -24,25 +22,8 @@ class CynthionPlatformRev1D2(LUNAApolloPlatform, LatticeECP5Platform):
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
-    default_clk = "clk_60MHz"
-
-    # Provide the type that'll be used to create our clock domains.
-    clock_domain_generator = LunaECP5DomainGenerator
-
     # By default, assume we'll be connecting via our target PHY.
     default_usb_connection = "target_phy"
-
-    #
-    # Default clock frequencies for each of our clock domains.
-    #
-    # Different revisions have different FPGA speed grades, and thus the
-    # default frequencies will vary.
-    #
-    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
-        "fast": 240,
-        "sync": 120,
-        "usb":  60
-    }
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.
@@ -52,13 +33,6 @@ class CynthionPlatformRev1D2(LUNAApolloPlatform, LatticeECP5Platform):
         # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
         clock_skew = 127
     )
-
-    # Provides any platform-specific ULPI registers necessary.
-    # This is the spot to put any platform-specific vendor registers that need
-    # to be written.
-    ulpi_extra_registers = {
-        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
-    }
 
     #
     # I/O resources.
@@ -207,10 +181,3 @@ class CynthionPlatformRev1D2(LUNAApolloPlatform, LatticeECP5Platform):
         Connector("mezzanine", 0,
             "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),
     ]
-
-    def toolchain_prepare(self, fragment, name, **kwargs):
-        overrides = {
-            'ecppack_opts': '--compress --freq 38.8'
-        }
-
-        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)

--- a/cynthion/python/src/gateware/platform/cynthion_r1_3.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_3.py
@@ -7,15 +7,13 @@
 import os
 
 from amaranth.build import *
-from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 from amaranth_boards.resources import *
 
-from luna.gateware.platform.core import LUNAApolloPlatform
-from luna.gateware.architecture.car import LunaECP5DomainGenerator
+from cynthion.gateware.platform.core import CynthionPlatform
 
 __all__ = ["CynthionPlatformRev1D3"]
 
-class CynthionPlatformRev1D3(LUNAApolloPlatform, LatticeECP5Platform):
+class CynthionPlatformRev1D3(CynthionPlatform):
     """ Board description for Cynthion r1.3 """
 
     name        = "Cynthion r1.3"
@@ -24,25 +22,8 @@ class CynthionPlatformRev1D3(LUNAApolloPlatform, LatticeECP5Platform):
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
-    default_clk = "clk_60MHz"
-
-    # Provide the type that'll be used to create our clock domains.
-    clock_domain_generator = LunaECP5DomainGenerator
-
     # By default, assume we'll be connecting via our target PHY.
     default_usb_connection = "target_phy"
-
-    #
-    # Default clock frequencies for each of our clock domains.
-    #
-    # Different revisions have different FPGA speed grades, and thus the
-    # default frequencies will vary.
-    #
-    DEFAULT_CLOCK_FREQUENCIES_MHZ = {
-        "fast": 240,
-        "sync": 120,
-        "usb":  60
-    }
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.
@@ -52,13 +33,6 @@ class CynthionPlatformRev1D3(LUNAApolloPlatform, LatticeECP5Platform):
         # TODO: remove this & use the PLL to produce a 90degree clock signal instead.
         clock_skew = 127
     )
-
-    # Provides any platform-specific ULPI registers necessary.
-    # This is the spot to put any platform-specific vendor registers that need
-    # to be written.
-    ulpi_extra_registers = {
-        0x39: 0b000110 # USB3343: swap D+ and D- to match the hardware design
-    }
 
     #
     # I/O resources.
@@ -207,10 +181,3 @@ class CynthionPlatformRev1D3(LUNAApolloPlatform, LatticeECP5Platform):
         Connector("mezzanine", 0,
             "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),
     ]
-
-    def toolchain_prepare(self, fragment, name, **kwargs):
-        overrides = {
-            'ecppack_opts': '--compress --freq 38.8'
-        }
-
-        return super().toolchain_prepare(fragment, name, **overrides, **kwargs)


### PR DESCRIPTION
This PR creates a new `CynthionPlatform` class that gathers common methods and attributes and serves as a foundation for all Cynthion boards.

`CynthionPlatform` also adds support for adding custom, board-specific fragments.
A common `pseudo_power_supply_fragment` is added to wire the pseudo power supply pins to the power rails.