### PR TITLE
gateware: fix platform >= 0.7 pmod a connector pins

### DIFF
--- a/cynthion/python/src/gateware/platform/cynthion_r0_7.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_7.py
@@ -164,7 +164,7 @@ class CynthionPlatformRev0D7(CynthionPlatform):
     ]
 
     connectors = [
-        Connector("pmod", 0, "C9 C8 D11 C12 - - B8 D8 D9 C10 - -"), # PMOD A
+        Connector("pmod", 0, "C9 B9 D11 C12 - - C8 D8 D9 C10 - -"), # PMOD A
         Connector("pmod", 1, "B4 B5 B6 B7 - - C5 A5 A6 A7 - -"), # PMOD B
         Connector("mezzanine", 0,
             "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),

--- a/cynthion/python/src/gateware/platform/cynthion_r1_0.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_0.py
@@ -164,7 +164,7 @@ class CynthionPlatformRev1D0(CynthionPlatform):
     ]
 
     connectors = [
-        Connector("pmod", 0, "C9 C8 D11 C12 - - B8 D8 D9 C10 - -"), # PMOD A
+        Connector("pmod", 0, "C9 B9 D11 C12 - - C8 D8 D9 C10 - -"), # PMOD A
         Connector("pmod", 1, "B4 B5 B6 B7 - - C5 A5 A6 A7 - -"), # PMOD B
         Connector("mezzanine", 0,
             "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),

--- a/cynthion/python/src/gateware/platform/cynthion_r1_1.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_1.py
@@ -164,7 +164,7 @@ class CynthionPlatformRev1D1(CynthionPlatform):
     ]
 
     connectors = [
-        Connector("pmod", 0, "C9 C8 D11 C12 - - B8 D8 D9 C10 - -"), # PMOD A
+        Connector("pmod", 0, "C9 B9 D11 C12 - - C8 D8 D9 C10 - -"), # PMOD A
         Connector("pmod", 1, "B4 B5 B6 B7 - - C5 A5 A6 A7 - -"), # PMOD B
         Connector("mezzanine", 0,
             "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),

--- a/cynthion/python/src/gateware/platform/cynthion_r1_2.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_2.py
@@ -176,7 +176,7 @@ class CynthionPlatformRev1D2(CynthionPlatform):
     ]
 
     connectors = [
-        Connector("pmod", 0, "C9 C8 D11 C12 - - B8 D8 D9 C10 - -"), # PMOD A
+        Connector("pmod", 0, "C9 B9 D11 C12 - - C8 D8 D9 C10 - -"), # PMOD A
         Connector("pmod", 1, "B4 B5 B6 B7 - - C5 A5 A6 A7 - -"), # PMOD B
         Connector("mezzanine", 0,
             "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),

--- a/cynthion/python/src/gateware/platform/cynthion_r1_3.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_3.py
@@ -176,7 +176,7 @@ class CynthionPlatformRev1D3(CynthionPlatform):
     ]
 
     connectors = [
-        Connector("pmod", 0, "C9 C8 D11 C12 - - B8 D8 D9 C10 - -"), # PMOD A
+        Connector("pmod", 0, "C9 B9 D11 C12 - - C8 D8 D9 C10 - -"), # PMOD A
         Connector("pmod", 1, "B4 B5 B6 B7 - - C5 A5 A6 A7 - -"), # PMOD B
         Connector("mezzanine", 0,
             "- - B8 A9 B10 A10 B11 D14 C14 F14 E14 G13 G12 - - - - C16 C15 B16 B15 A14 B13 A13 D13 A12 B12 A11 - -"),


### PR DESCRIPTION
With `r0.7` the assignment for the PMOD A pins changed.

While the `Resource` definitions were updated the change was not propogated to the `Connector` definitions.
