### PR TITLE
repo: drop amaranth as a dependency for the cynthion package

### DIFF
--- a/cynthion/python/pyproject.toml
+++ b/cynthion/python/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
 
 [project.optional-dependencies]
 gateware = [
-    "amaranth @ git+https://github.com/amaranth-lang/amaranth",
     "luna @ git+https://github.com/greatscottgadgets/luna@main",
 ]
 gateware-soc = [


### PR DESCRIPTION
It's already being pulled in via `luna`.