### PR TITLE
ci: specify python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ RUN apt-get update && apt-get install -y \
     libreadline-dev \
     openocd \
     pkg-config \
-    python3 \
+    python3.11 \
+    python3.11-venv \
     python3-pip \
-    python3-venv \
     tcl \
     tcl-dev \
     zlib1g-dev \

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-python3 -m venv ci_env
+python3.11 -m venv ci_env
 source ci_env/bin/activate
 pip install --upgrade cynthion/python/.[gateware,gateware-soc]
 deactivate

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,5 +3,5 @@ set -e
 usbhub --disable-i2c --hub D9D1 power state --port 3 --reset
 sleep 1s
 source ci_env/bin/activate
-python ci/interactive-test.py
+python3.11 ci/interactive-test.py
 deactivate


### PR DESCRIPTION
This should fix the `tomllib` error in Jenkins.