### PR TITLE
repo: add amaranth-stdio to python dependencies

### DIFF
--- a/cynthion/python/pyproject.toml
+++ b/cynthion/python/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "amaranth==0.4.1",
+    "amaranth-stdio @ git+https://github.com/amaranth-lang/amaranth-stdio@f41e7e5",
     "pyusb",
     "future",
     "pyfwup>=0.2",


### PR DESCRIPTION
This PR bumps the amaranth-stdio dependency to [4a14bb17](https://github.com/amaranth-lang/amaranth-stdio/commit/4a14bb17c2c38374dc720473ee714247e8ae6b8a)

This is the latest version that:

1. Does not pull in amaranth from git.
2.  Also works with LambdaSoC.