### PR TITLE
repo: move amaranth and amaranth-stdio to optional-dependencies for gateware

### DIFF
--- a/cynthion/python/constrains.txt
+++ b/cynthion/python/constrains.txt
@@ -1,3 +1,3 @@
 amaranth==0.4.1
-amaranth-stdio @ git+https://github.com/amaranth-lang/amaranth-stdio@f41e7e5
+amaranth-stdio @ git+https://github.com/amaranth-lang/amaranth-stdio@4a14bb17
 amaranth-soc @ git+https://github.com/amaranth-lang/amaranth-soc@d2185e3

--- a/cynthion/python/pyproject.toml
+++ b/cynthion/python/pyproject.toml
@@ -27,8 +27,6 @@ classifiers = [
     "Topic :: Security",
 ]
 dependencies = [
-    "amaranth==0.4.1",
-    "amaranth-stdio @ git+https://github.com/amaranth-lang/amaranth-stdio@f41e7e5",
     "pyusb",
     "future",
     "pyfwup>=0.2",
@@ -43,6 +41,8 @@ dependencies = [
 
 [project.optional-dependencies]
 gateware = [
+    "amaranth==0.4.1",
+    "amaranth-stdio @ git+https://github.com/amaranth-lang/amaranth-stdio@4a14bb17",
     "luna @ git+https://github.com/greatscottgadgets/luna@main",
 ]
 gateware-soc = [


### PR DESCRIPTION
Also updates amaranth-stdio `constrains.txt` entry to match `pyproject.toml`