### PR TITLE
moondancer: use Cynthion control port instead of aux port

### DIFF
--- a/cynthion/python/src/gateware/soc/advertiser.py
+++ b/cynthion/python/src/gateware/soc/advertiser.py
@@ -1,0 +1,56 @@
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2024 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+from amaranth               import Cat, Elaboratable, Module, Signal, Record
+from luna.gateware.platform import NullPin
+from luna_soc.gateware.csr  import Peripheral
+
+from apollo_fpga.gateware   import ApolloAdvertiser
+
+class ApolloAdvertiserPeripheral(Peripheral, Elaboratable):
+    """ Controller peripheral for ApolloAdvertiser
+
+    CSR registers
+    -------------
+    enable : read/write
+        Set this bit to '1' to start ApolloAdvertiser and disconnect the Cynthion USB control port from Apollo.
+    """
+
+    def __init__(self, clk_freq_hz=None):
+        super().__init__()
+
+        self._clk_freq = clk_freq_hz
+
+        #
+        # Registers
+        #
+
+        regs         = self.csr_bank()
+        self._enable = regs.csr(1, "rw", desc="""
+            Set this bit to '1' to start ApolloAdvertiser and disconnect the Cynthion USB control port from Apollo.
+        """)
+
+        # wishbone connection
+        self._bridge = self.bridge(data_width=32, granularity=8, alignment=2)
+        self.bus     = self._bridge.bus
+
+
+    def elaborate(self, platform):
+        m = Module()
+        m.submodules.bridge = self._bridge
+
+        # advertiser stop signal is enabled by default
+        stop = Signal(reset=1)
+
+        # update advertiser stop signal on register write
+        with m.If(self._enable.w_stb):
+            m.d.sync += stop.eq(~self._enable.w_data)
+
+        # create advertiser
+        m.submodules.advertiser = advertiser = ApolloAdvertiser(clk_freq_hz=self._clk_freq)
+        m.d.comb += advertiser.stop.eq(stop)
+
+        return m

--- a/firmware/lunasoc-hal/src/gpio.rs
+++ b/firmware/lunasoc-hal/src/gpio.rs
@@ -15,7 +15,6 @@ macro_rules! impl_gpio {
                 }
             }
 
-            //impl $crate::hal::digital::v2::OutputPin for $GPIOX {
             impl embedded_hal_0::digital::v2::OutputPin for $GPIOX {
                 type Error = core::convert::Infallible;
 
@@ -43,7 +42,6 @@ macro_rules! impl_gpio {
                 }
             }
 
-            //impl $crate::hal::digital::v2::StatefulOutputPin for $GPIOX {
             impl embedded_hal_0::digital::v2::StatefulOutputPin for $GPIOX {
                 fn is_set_low(&self) -> Result<bool, Self::Error> {
                     let reg = unsafe { &*<$PACGPIOX>::ptr() };
@@ -60,8 +58,6 @@ macro_rules! impl_gpio {
             }
 
             /// Opt-in to the software implementation.
-            //use embedded_hal_0::digital::v2::toggleable as _;
-            //impl $crate::hal_0::digital::v2::toggleable::Default for $GPIOX {}
             impl embedded_hal_0::digital::v2::toggleable::Default for $GPIOX {}
         )+
     }

--- a/firmware/lunasoc-hal/src/lib.rs
+++ b/firmware/lunasoc-hal/src/lib.rs
@@ -11,8 +11,8 @@ pub mod timer;
 pub mod usb;
 
 // export peripherals
-pub use serial::Serial;
-pub use timer::Timer;
+pub use serial::{Serial0, Serial1};
+pub use timer::Timer0;
 #[cfg(feature = "usb")]
 pub use usb::{Usb0, Usb1, Usb2};
 

--- a/firmware/lunasoc-hal/src/serial.rs
+++ b/firmware/lunasoc-hal/src/serial.rs
@@ -4,23 +4,23 @@ pub use crate::hal::serial::ErrorKind as Error;
 #[macro_export]
 macro_rules! impl_serial {
     ($(
-        $SERIALX:ident: $PACUARTX:ty,
+        $SERIALX:ident: $UARTX:ident,
     )+) => {
         $(
             #[derive(Debug)]
             pub struct $SERIALX {
-                registers: $PACUARTX,
+                registers: $crate::pac::$UARTX,
             }
 
             // lifecycle
             impl $SERIALX {
                 /// Create a new `Serial` from the [`UART`](crate::pac::UART) peripheral.
-                pub fn new(registers: $PACUARTX) -> Self {
+                pub fn new(registers: $crate::pac::$UARTX) -> Self {
                     Self { registers }
                 }
 
                 /// Release the [`Uart`](crate::pac::UART) peripheral and consume self.
-                pub fn free(self) -> $PACUARTX {
+                pub fn free(self) -> $crate::pac::$UARTX {
                     self.registers
                 }
 
@@ -31,14 +31,14 @@ macro_rules! impl_serial {
                 /// 'Tis thine responsibility, that which thou doth summon.
                 pub unsafe fn summon() -> Self {
                     Self {
-                        registers: $crate::pac::Peripherals::steal().UART,
+                        registers: $crate::pac::Peripherals::steal().$UARTX,
                     }
                 }
             }
 
             // trait: From
-            impl From<$PACUARTX> for $SERIALX {
-                fn from(registers: $PACUARTX) -> $SERIALX {
+            impl From<$crate::pac::$UARTX> for $SERIALX {
+                fn from(registers: $crate::pac::$UARTX) -> $SERIALX {
                     $SERIALX::new(registers)
                 }
             }
@@ -53,82 +53,92 @@ macro_rules! impl_serial {
                 }
             }
 
-            mod embedded_hal_1 {
+            #[allow(non_snake_case)]
+            mod $UARTX {
                 use super::$SERIALX;
 
-                // trait: hal::serial::ErrorType
-                impl $crate::hal::serial::ErrorType for $SERIALX {
-                    type Error = $crate::serial::Error;
-                }
+                // embedded_hal 1.0 traits
+                mod embedded_hal_1 {
+                    use super::$SERIALX;
 
-                // trait: hal::serial::Write
-                impl $crate::hal::serial::Write<u8> for $SERIALX {
-                    fn write(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
-                        for &word in buffer {
+                    // trait: hal::serial::ErrorType
+                    impl $crate::hal::serial::ErrorType for $SERIALX {
+                        type Error = $crate::serial::Error;
+                    }
+
+                    // trait: hal::serial::Write
+                    impl $crate::hal::serial::Write<u8> for $SERIALX {
+                        fn write(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
+                            for &byte in buffer {
+                                $crate::nb::block!(
+                                    <$SERIALX as $crate::hal_nb::serial::Write<u8>>::write(self, byte)
+                                )?;
+                            }
+                            Ok(())
+                        }
+
+                        fn flush(&mut self) -> Result<(), Self::Error> {
                             $crate::nb::block!(
-                                <$SERIALX as $crate::hal_nb::serial::Write<u8>>::write(self, word)
-                            )?;
-                        }
-                        Ok(())
-                    }
-
-                    fn flush(&mut self) -> Result<(), Self::Error> {
-                        $crate::nb::block!(
-                            <$SERIALX as $crate::hal_nb::serial::Write<u8>>::flush(self)
-                        )
-                    }
-                }
-
-                // trait: hal_nb::serial::Write
-                impl $crate::hal_nb::serial::Write<u8> for $SERIALX {
-                    fn write(&mut self, word: u8) -> $crate::nb::Result<(), Self::Error> {
-                        if self.registers.tx_rdy().read().tx_rdy().bit() == false {
-                            Err($crate::nb::Error::WouldBlock)
-                        } else {
-                            self.registers.tx_data().write(|w| unsafe { w.tx_data().bits(word.into()) });
-                            Ok(())
+                                <$SERIALX as $crate::hal_nb::serial::Write<u8>>::flush(self)
+                            )
                         }
                     }
 
-                    fn flush(&mut self) -> $crate::nb::Result<(), Self::Error> {
-                        if self.registers.tx_rdy().read().tx_rdy().bit() == true {
-                            Ok(())
-                        } else {
-                            Err($crate::nb::Error::WouldBlock)
+                    // trait: hal_nb::serial::Write
+                    impl $crate::hal_nb::serial::Write<u8> for $SERIALX {
+                        fn write(&mut self, byte: u8) -> $crate::nb::Result<(), Self::Error> {
+                            if self.registers.tx_rdy().read().tx_rdy().bit() {
+                                self.registers.tx_data().write(|w| unsafe { w.tx_data().bits(byte.into()) });
+                                Ok(())
+                            } else {
+                                Err($crate::nb::Error::WouldBlock)
+                            }
                         }
-                    }
-                }
-            }
 
-            mod embedded_hal_0 {
-                use super::$SERIALX;
-
-                // trait: hal::serial::Write
-                impl $crate::hal_0::serial::Write<u8> for $SERIALX {
-                    type Error = $crate::serial::Error;
-
-                    fn write(&mut self, word: u8) -> $crate::nb::Result<(), Self::Error> {
-                        if self.registers.tx_rdy().read().tx_rdy().bit() == false {
-                            Err($crate::nb::Error::WouldBlock)
-                        } else {
-                            self.registers.tx_data().write(|w| unsafe { w.tx_data().bits(word.into()) });
-                            Ok(())
-                        }
-                    }
-                    fn flush(&mut self) -> $crate::nb::Result<(), Self::Error> {
-                        if self.registers.tx_rdy().read().tx_rdy().bit() == true {
-                            Ok(())
-                        } else {
-                            Err($crate::nb::Error::WouldBlock)
+                        fn flush(&mut self) -> $crate::nb::Result<(), Self::Error> {
+                            if self.registers.tx_rdy().read().tx_rdy().bit() {
+                                Ok(())
+                            } else {
+                                Err($crate::nb::Error::WouldBlock)
+                            }
                         }
                     }
                 }
 
-                // trait: hal::blocking::serial::write::Default
-                impl $crate::hal_0::blocking::serial::write::Default<u8> for $SERIALX {}
+                // embedded_hal 0.x traits
+                mod embedded_hal_0 {
+                    use super::$SERIALX;
+
+                    // trait: hal::serial::Write
+                    impl $crate::hal_0::serial::Write<u8> for $SERIALX {
+                        type Error = $crate::serial::Error;
+
+                        fn write(&mut self, byte: u8) -> $crate::nb::Result<(), Self::Error> {
+                            if self.registers.tx_rdy().read().tx_rdy().bit() {
+                                self.registers.tx_data().write(|w| unsafe { w.tx_data().bits(byte.into()) });
+                                Ok(())
+                            } else {
+                                Err($crate::nb::Error::WouldBlock)
+                            }
+                        }
+                        fn flush(&mut self) -> $crate::nb::Result<(), Self::Error> {
+                            if self.registers.tx_rdy().read().tx_rdy().bit() {
+                                Ok(())
+                            } else {
+                                Err($crate::nb::Error::WouldBlock)
+                            }
+                        }
+                    }
+
+                    // trait: hal::blocking::serial::write::Default
+                    impl $crate::hal_0::blocking::serial::write::Default<u8> for $SERIALX {}
+                }
             }
         )+
     }
 }
 
-impl_serial! { Serial: crate::pac::UART, }
+impl_serial! {
+    Serial0: UART,
+    Serial1: UART1,
+}

--- a/firmware/lunasoc-hal/src/timer.rs
+++ b/firmware/lunasoc-hal/src/timer.rs
@@ -144,4 +144,4 @@ macro_rules! impl_timer {
     }
 }
 
-crate::impl_timer! { Timer: crate::pac::TIMER, }
+crate::impl_timer! { Timer0: crate::pac::TIMER, }

--- a/firmware/lunasoc-pac/device.x
+++ b/firmware/lunasoc-pac/device.x
@@ -14,4 +14,5 @@ PROVIDE(USB2 = DefaultHandler);
 PROVIDE(USB2_EP_CONTROL = DefaultHandler);
 PROVIDE(USB2_EP_IN = DefaultHandler);
 PROVIDE(USB2_EP_OUT = DefaultHandler);
+PROVIDE(UART1 = DefaultHandler);
 

--- a/firmware/lunasoc-pac/src/generated.rs
+++ b/firmware/lunasoc-pac/src/generated.rs
@@ -24,6 +24,7 @@ extern "C" {
     fn USB2_EP_CONTROL();
     fn USB2_EP_IN();
     fn USB2_EP_OUT();
+    fn UART1();
 }
 #[doc(hidden)]
 #[repr(C)]
@@ -34,7 +35,7 @@ pub union Vector {
 #[cfg(feature = "rt")]
 #[doc(hidden)]
 #[no_mangle]
-pub static __EXTERNAL_INTERRUPTS: [Vector; 16] = [
+pub static __EXTERNAL_INTERRUPTS: [Vector; 17] = [
     Vector { _handler: TIMER },
     Vector { _handler: UART },
     Vector { _handler: GPIOA },
@@ -69,6 +70,7 @@ pub static __EXTERNAL_INTERRUPTS: [Vector; 16] = [
     Vector {
         _handler: USB2_EP_OUT,
     },
+    Vector { _handler: UART1 },
 ];
 #[doc(hidden)]
 pub mod interrupt;
@@ -855,6 +857,98 @@ impl core::fmt::Debug for USB2_EP_OUT {
 }
 #[doc = "USB2_EP_OUT"]
 pub mod usb2_ep_out;
+#[doc = "UART1"]
+pub struct UART1 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for UART1 {}
+impl UART1 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const uart1::RegisterBlock = 0xf000_6000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const uart1::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for UART1 {
+    type Target = uart1::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for UART1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UART1").finish()
+    }
+}
+#[doc = "UART1"]
+pub mod uart1;
+#[doc = "ADVERTISER"]
+pub struct ADVERTISER {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ADVERTISER {}
+impl ADVERTISER {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const advertiser::RegisterBlock = 0xf000_7000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const advertiser::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ADVERTISER {
+    type Target = advertiser::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ADVERTISER {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ADVERTISER").finish()
+    }
+}
+#[doc = "ADVERTISER"]
+pub mod advertiser;
 #[no_mangle]
 static mut DEVICE_PERIPHERALS: bool = false;
 #[doc = r" All the peripherals."]
@@ -894,6 +988,10 @@ pub struct Peripherals {
     pub USB2_EP_IN: USB2_EP_IN,
     #[doc = "USB2_EP_OUT"]
     pub USB2_EP_OUT: USB2_EP_OUT,
+    #[doc = "UART1"]
+    pub UART1: UART1,
+    #[doc = "ADVERTISER"]
+    pub ADVERTISER: ADVERTISER,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -965,6 +1063,12 @@ impl Peripherals {
                 _marker: PhantomData,
             },
             USB2_EP_OUT: USB2_EP_OUT {
+                _marker: PhantomData,
+            },
+            UART1: UART1 {
+                _marker: PhantomData,
+            },
+            ADVERTISER: ADVERTISER {
                 _marker: PhantomData,
             },
         }

--- a/firmware/lunasoc-pac/src/generated/advertiser.rs
+++ b/firmware/lunasoc-pac/src/generated/advertiser.rs
@@ -1,0 +1,17 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    enable: ENABLE,
+}
+impl RegisterBlock {
+    #[doc = "0x00 - advertiser enable register"]
+    #[inline(always)]
+    pub const fn enable(&self) -> &ENABLE {
+        &self.enable
+    }
+}
+#[doc = "enable (rw) register accessor: advertiser enable register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable`]
+module"]
+pub type ENABLE = crate::Reg<enable::ENABLE_SPEC>;
+#[doc = "advertiser enable register"]
+pub mod enable;

--- a/firmware/lunasoc-pac/src/generated/advertiser/enable.rs
+++ b/firmware/lunasoc-pac/src/generated/advertiser/enable.rs
@@ -1,0 +1,49 @@
+#[doc = "Register `enable` reader"]
+pub type R = crate::R<ENABLE_SPEC>;
+#[doc = "Register `enable` writer"]
+pub type W = crate::W<ENABLE_SPEC>;
+#[doc = "Field `enable` reader - Set this bit to '1' to start ApolloAdvertiser and disconnect the Cynthion USB control port from Apollo."]
+pub type ENABLE_R = crate::BitReader;
+#[doc = "Field `enable` writer - Set this bit to '1' to start ApolloAdvertiser and disconnect the Cynthion USB control port from Apollo."]
+pub type ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0 - Set this bit to '1' to start ApolloAdvertiser and disconnect the Cynthion USB control port from Apollo."]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new((self.bits & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Set this bit to '1' to start ApolloAdvertiser and disconnect the Cynthion USB control port from Apollo."]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "advertiser enable register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct ENABLE_SPEC;
+impl crate::RegisterSpec for ENABLE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`enable::R`](R) reader structure"]
+impl crate::Readable for ENABLE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`enable::W`](W) writer structure"]
+impl crate::Writable for ENABLE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets enable to value 0"]
+impl crate::Resettable for ENABLE_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/firmware/lunasoc-pac/src/generated/interrupt.rs
+++ b/firmware/lunasoc-pac/src/generated/interrupt.rs
@@ -34,6 +34,8 @@ pub enum Interrupt {
     USB2_EP_IN = 14,
     #[doc = "15 - usb2_ep_out"]
     USB2_EP_OUT = 15,
+    #[doc = "16 - uart1"]
+    UART1 = 16,
 }
 #[doc = r" TryFromInterruptError"]
 #[derive(Debug, Copy, Clone)]
@@ -59,6 +61,7 @@ impl Interrupt {
             13 => Ok(Interrupt::USB2_EP_CONTROL),
             14 => Ok(Interrupt::USB2_EP_IN),
             15 => Ok(Interrupt::USB2_EP_OUT),
+            16 => Ok(Interrupt::UART1),
             _ => Err(TryFromInterruptError(())),
         }
     }

--- a/firmware/lunasoc-pac/src/generated/uart1.rs
+++ b/firmware/lunasoc-pac/src/generated/uart1.rs
@@ -1,0 +1,106 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    divisor: DIVISOR,
+    rx_data: RX_DATA,
+    rx_rdy: RX_RDY,
+    rx_err: RX_ERR,
+    tx_data: TX_DATA,
+    tx_rdy: TX_RDY,
+    _reserved6: [u8; 0x08],
+    ev_status: EV_STATUS,
+    ev_pending: EV_PENDING,
+    ev_enable: EV_ENABLE,
+}
+impl RegisterBlock {
+    #[doc = "0x00 - uart1 divisor register"]
+    #[inline(always)]
+    pub const fn divisor(&self) -> &DIVISOR {
+        &self.divisor
+    }
+    #[doc = "0x04 - uart1 rx_data register"]
+    #[inline(always)]
+    pub const fn rx_data(&self) -> &RX_DATA {
+        &self.rx_data
+    }
+    #[doc = "0x08 - uart1 rx_rdy register"]
+    #[inline(always)]
+    pub const fn rx_rdy(&self) -> &RX_RDY {
+        &self.rx_rdy
+    }
+    #[doc = "0x0c - uart1 rx_err register"]
+    #[inline(always)]
+    pub const fn rx_err(&self) -> &RX_ERR {
+        &self.rx_err
+    }
+    #[doc = "0x10 - uart1 tx_data register"]
+    #[inline(always)]
+    pub const fn tx_data(&self) -> &TX_DATA {
+        &self.tx_data
+    }
+    #[doc = "0x14 - uart1 tx_rdy register"]
+    #[inline(always)]
+    pub const fn tx_rdy(&self) -> &TX_RDY {
+        &self.tx_rdy
+    }
+    #[doc = "0x20 - uart1 ev_status register"]
+    #[inline(always)]
+    pub const fn ev_status(&self) -> &EV_STATUS {
+        &self.ev_status
+    }
+    #[doc = "0x24 - uart1 ev_pending register"]
+    #[inline(always)]
+    pub const fn ev_pending(&self) -> &EV_PENDING {
+        &self.ev_pending
+    }
+    #[doc = "0x28 - uart1 ev_enable register"]
+    #[inline(always)]
+    pub const fn ev_enable(&self) -> &EV_ENABLE {
+        &self.ev_enable
+    }
+}
+#[doc = "divisor (rw) register accessor: uart1 divisor register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`divisor::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`divisor::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@divisor`]
+module"]
+pub type DIVISOR = crate::Reg<divisor::DIVISOR_SPEC>;
+#[doc = "uart1 divisor register"]
+pub mod divisor;
+#[doc = "rx_data (r) register accessor: uart1 rx_data register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rx_data::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@rx_data`]
+module"]
+pub type RX_DATA = crate::Reg<rx_data::RX_DATA_SPEC>;
+#[doc = "uart1 rx_data register"]
+pub mod rx_data;
+#[doc = "rx_rdy (r) register accessor: uart1 rx_rdy register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rx_rdy::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@rx_rdy`]
+module"]
+pub type RX_RDY = crate::Reg<rx_rdy::RX_RDY_SPEC>;
+#[doc = "uart1 rx_rdy register"]
+pub mod rx_rdy;
+#[doc = "rx_err (r) register accessor: uart1 rx_err register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rx_err::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@rx_err`]
+module"]
+pub type RX_ERR = crate::Reg<rx_err::RX_ERR_SPEC>;
+#[doc = "uart1 rx_err register"]
+pub mod rx_err;
+#[doc = "tx_data (w) register accessor: uart1 tx_data register\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tx_data::W`]. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tx_data`]
+module"]
+pub type TX_DATA = crate::Reg<tx_data::TX_DATA_SPEC>;
+#[doc = "uart1 tx_data register"]
+pub mod tx_data;
+#[doc = "tx_rdy (r) register accessor: uart1 tx_rdy register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tx_rdy::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@tx_rdy`]
+module"]
+pub type TX_RDY = crate::Reg<tx_rdy::TX_RDY_SPEC>;
+#[doc = "uart1 tx_rdy register"]
+pub mod tx_rdy;
+#[doc = "ev_status (r) register accessor: uart1 ev_status register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ev_status::R`].  See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@ev_status`]
+module"]
+pub type EV_STATUS = crate::Reg<ev_status::EV_STATUS_SPEC>;
+#[doc = "uart1 ev_status register"]
+pub mod ev_status;
+#[doc = "ev_pending (rw) register accessor: uart1 ev_pending register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ev_pending::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ev_pending::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@ev_pending`]
+module"]
+pub type EV_PENDING = crate::Reg<ev_pending::EV_PENDING_SPEC>;
+#[doc = "uart1 ev_pending register"]
+pub mod ev_pending;
+#[doc = "ev_enable (rw) register accessor: uart1 ev_enable register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ev_enable::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ev_enable::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@ev_enable`]
+module"]
+pub type EV_ENABLE = crate::Reg<ev_enable::EV_ENABLE_SPEC>;
+#[doc = "uart1 ev_enable register"]
+pub mod ev_enable;

--- a/firmware/lunasoc-pac/src/generated/uart1/divisor.rs
+++ b/firmware/lunasoc-pac/src/generated/uart1/divisor.rs
@@ -1,0 +1,49 @@
+#[doc = "Register `divisor` reader"]
+pub type R = crate::R<DIVISOR_SPEC>;
+#[doc = "Register `divisor` writer"]
+pub type W = crate::W<DIVISOR_SPEC>;
+#[doc = "Field `divisor` reader - uart1 divisor register field"]
+pub type DIVISOR_R = crate::FieldReader<u16>;
+#[doc = "Field `divisor` writer - uart1 divisor register field"]
+pub type DIVISOR_W<'a, REG> = crate::FieldWriter<'a, REG, 10, u16>;
+impl R {
+    #[doc = "Bits 0:9 - uart1 divisor register field"]
+    #[inline(always)]
+    pub fn divisor(&self) -> DIVISOR_R {
+        DIVISOR_R::new((self.bits & 0x03ff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:9 - uart1 divisor register field"]
+    #[inline(always)]
+    #[must_use]
+    pub fn divisor(&mut self) -> DIVISOR_W<DIVISOR_SPEC> {
+        DIVISOR_W::new(self, 0)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "uart1 divisor register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`divisor::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`divisor::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct DIVISOR_SPEC;
+impl crate::RegisterSpec for DIVISOR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`divisor::R`](R) reader structure"]
+impl crate::Readable for DIVISOR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`divisor::W`](W) writer structure"]
+impl crate::Writable for DIVISOR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets divisor to value 0"]
+impl crate::Resettable for DIVISOR_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/firmware/lunasoc-pac/src/generated/uart1/ev_enable.rs
+++ b/firmware/lunasoc-pac/src/generated/uart1/ev_enable.rs
@@ -1,0 +1,49 @@
+#[doc = "Register `ev_enable` reader"]
+pub type R = crate::R<EV_ENABLE_SPEC>;
+#[doc = "Register `ev_enable` writer"]
+pub type W = crate::W<EV_ENABLE_SPEC>;
+#[doc = "Field `enable` reader - uart1 enable register field"]
+pub type ENABLE_R = crate::FieldReader;
+#[doc = "Field `enable` writer - uart1 enable register field"]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+impl R {
+    #[doc = "Bits 0:2 - uart1 enable register field"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new((self.bits & 7) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - uart1 enable register field"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<EV_ENABLE_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "uart1 ev_enable register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ev_enable::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ev_enable::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct EV_ENABLE_SPEC;
+impl crate::RegisterSpec for EV_ENABLE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`ev_enable::R`](R) reader structure"]
+impl crate::Readable for EV_ENABLE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ev_enable::W`](W) writer structure"]
+impl crate::Writable for EV_ENABLE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets ev_enable to value 0"]
+impl crate::Resettable for EV_ENABLE_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/firmware/lunasoc-pac/src/generated/uart1/ev_pending.rs
+++ b/firmware/lunasoc-pac/src/generated/uart1/ev_pending.rs
@@ -1,0 +1,49 @@
+#[doc = "Register `ev_pending` reader"]
+pub type R = crate::R<EV_PENDING_SPEC>;
+#[doc = "Register `ev_pending` writer"]
+pub type W = crate::W<EV_PENDING_SPEC>;
+#[doc = "Field `pending` reader - uart1 pending register field"]
+pub type PENDING_R = crate::FieldReader;
+#[doc = "Field `pending` writer - uart1 pending register field"]
+pub type PENDING_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+impl R {
+    #[doc = "Bits 0:2 - uart1 pending register field"]
+    #[inline(always)]
+    pub fn pending(&self) -> PENDING_R {
+        PENDING_R::new((self.bits & 7) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - uart1 pending register field"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pending(&mut self) -> PENDING_W<EV_PENDING_SPEC> {
+        PENDING_W::new(self, 0)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "uart1 ev_pending register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ev_pending::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ev_pending::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct EV_PENDING_SPEC;
+impl crate::RegisterSpec for EV_PENDING_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`ev_pending::R`](R) reader structure"]
+impl crate::Readable for EV_PENDING_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ev_pending::W`](W) writer structure"]
+impl crate::Writable for EV_PENDING_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets ev_pending to value 0"]
+impl crate::Resettable for EV_PENDING_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/firmware/lunasoc-pac/src/generated/uart1/ev_status.rs
+++ b/firmware/lunasoc-pac/src/generated/uart1/ev_status.rs
@@ -1,0 +1,22 @@
+#[doc = "Register `ev_status` reader"]
+pub type R = crate::R<EV_STATUS_SPEC>;
+#[doc = "Field `status` reader - uart1 status register field"]
+pub type STATUS_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:2 - uart1 status register field"]
+    #[inline(always)]
+    pub fn status(&self) -> STATUS_R {
+        STATUS_R::new((self.bits & 7) as u8)
+    }
+}
+#[doc = "uart1 ev_status register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ev_status::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct EV_STATUS_SPEC;
+impl crate::RegisterSpec for EV_STATUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`ev_status::R`](R) reader structure"]
+impl crate::Readable for EV_STATUS_SPEC {}
+#[doc = "`reset()` method sets ev_status to value 0"]
+impl crate::Resettable for EV_STATUS_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/firmware/lunasoc-pac/src/generated/uart1/rx_data.rs
+++ b/firmware/lunasoc-pac/src/generated/uart1/rx_data.rs
@@ -1,0 +1,22 @@
+#[doc = "Register `rx_data` reader"]
+pub type R = crate::R<RX_DATA_SPEC>;
+#[doc = "Field `rx_data` reader - uart1 rx_data register field"]
+pub type RX_DATA_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - uart1 rx_data register field"]
+    #[inline(always)]
+    pub fn rx_data(&self) -> RX_DATA_R {
+        RX_DATA_R::new((self.bits & 0xff) as u8)
+    }
+}
+#[doc = "uart1 rx_data register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rx_data::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RX_DATA_SPEC;
+impl crate::RegisterSpec for RX_DATA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rx_data::R`](R) reader structure"]
+impl crate::Readable for RX_DATA_SPEC {}
+#[doc = "`reset()` method sets rx_data to value 0"]
+impl crate::Resettable for RX_DATA_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/firmware/lunasoc-pac/src/generated/uart1/rx_err.rs
+++ b/firmware/lunasoc-pac/src/generated/uart1/rx_err.rs
@@ -1,0 +1,22 @@
+#[doc = "Register `rx_err` reader"]
+pub type R = crate::R<RX_ERR_SPEC>;
+#[doc = "Field `rx_err` reader - uart1 rx_err register field"]
+pub type RX_ERR_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:2 - uart1 rx_err register field"]
+    #[inline(always)]
+    pub fn rx_err(&self) -> RX_ERR_R {
+        RX_ERR_R::new((self.bits & 7) as u8)
+    }
+}
+#[doc = "uart1 rx_err register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rx_err::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RX_ERR_SPEC;
+impl crate::RegisterSpec for RX_ERR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rx_err::R`](R) reader structure"]
+impl crate::Readable for RX_ERR_SPEC {}
+#[doc = "`reset()` method sets rx_err to value 0"]
+impl crate::Resettable for RX_ERR_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/firmware/lunasoc-pac/src/generated/uart1/rx_rdy.rs
+++ b/firmware/lunasoc-pac/src/generated/uart1/rx_rdy.rs
@@ -1,0 +1,22 @@
+#[doc = "Register `rx_rdy` reader"]
+pub type R = crate::R<RX_RDY_SPEC>;
+#[doc = "Field `rx_rdy` reader - uart1 rx_rdy register field"]
+pub type RX_RDY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - uart1 rx_rdy register field"]
+    #[inline(always)]
+    pub fn rx_rdy(&self) -> RX_RDY_R {
+        RX_RDY_R::new((self.bits & 1) != 0)
+    }
+}
+#[doc = "uart1 rx_rdy register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rx_rdy::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RX_RDY_SPEC;
+impl crate::RegisterSpec for RX_RDY_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rx_rdy::R`](R) reader structure"]
+impl crate::Readable for RX_RDY_SPEC {}
+#[doc = "`reset()` method sets rx_rdy to value 0"]
+impl crate::Resettable for RX_RDY_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/firmware/lunasoc-pac/src/generated/uart1/tx_data.rs
+++ b/firmware/lunasoc-pac/src/generated/uart1/tx_data.rs
@@ -1,0 +1,36 @@
+#[doc = "Register `tx_data` writer"]
+pub type W = crate::W<TX_DATA_SPEC>;
+#[doc = "Field `tx_data` writer - uart1 tx_data register field"]
+pub type TX_DATA_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+impl W {
+    #[doc = "Bits 0:7 - uart1 tx_data register field"]
+    #[inline(always)]
+    #[must_use]
+    pub fn tx_data(&mut self) -> TX_DATA_W<TX_DATA_SPEC> {
+        TX_DATA_W::new(self, 0)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "uart1 tx_data register\n\nYou can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tx_data::W`](W). See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TX_DATA_SPEC;
+impl crate::RegisterSpec for TX_DATA_SPEC {
+    type Ux = u32;
+}
+#[doc = "`write(|w| ..)` method takes [`tx_data::W`](W) writer structure"]
+impl crate::Writable for TX_DATA_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+}
+#[doc = "`reset()` method sets tx_data to value 0"]
+impl crate::Resettable for TX_DATA_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/firmware/lunasoc-pac/src/generated/uart1/tx_rdy.rs
+++ b/firmware/lunasoc-pac/src/generated/uart1/tx_rdy.rs
@@ -1,0 +1,22 @@
+#[doc = "Register `tx_rdy` reader"]
+pub type R = crate::R<TX_RDY_SPEC>;
+#[doc = "Field `tx_rdy` reader - uart1 tx_rdy register field"]
+pub type TX_RDY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - uart1 tx_rdy register field"]
+    #[inline(always)]
+    pub fn tx_rdy(&self) -> TX_RDY_R {
+        TX_RDY_R::new((self.bits & 1) != 0)
+    }
+}
+#[doc = "uart1 tx_rdy register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tx_rdy::R`](R).  See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TX_RDY_SPEC;
+impl crate::RegisterSpec for TX_RDY_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tx_rdy::R`](R) reader structure"]
+impl crate::Readable for TX_RDY_SPEC {}
+#[doc = "`reset()` method sets tx_rdy to value 0"]
+impl crate::Resettable for TX_RDY_SPEC {
+    const RESET_VALUE: u32 = 0;
+}

--- a/firmware/lunasoc-pac/src/generated/usb0_ep_control/data.rs
+++ b/firmware/lunasoc-pac/src/generated/usb0_ep_control/data.rs
@@ -1,9 +1,9 @@
 #[doc = "Register `data` reader"]
 pub type R = crate::R<DATA_SPEC>;
-#[doc = "Field `data` reader - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this conain the core SETUP packet."]
+#[doc = "Field `data` reader - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this contain the core SETUP packet."]
 pub type DATA_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:7 - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this conain the core SETUP packet."]
+    #[doc = "Bits 0:7 - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this contain the core SETUP packet."]
     #[inline(always)]
     pub fn data(&self) -> DATA_R {
         DATA_R::new((self.bits & 0xff) as u8)

--- a/firmware/lunasoc-pac/src/generated/usb0_ep_control/epno.rs
+++ b/firmware/lunasoc-pac/src/generated/usb0_ep_control/epno.rs
@@ -1,9 +1,9 @@
 #[doc = "Register `epno` reader"]
 pub type R = crate::R<EPNO_SPEC>;
-#[doc = "Field `epno` reader - The number of the endpoint associated with the current SETUP packet."]
+#[doc = "Field `epno` reader - The endpoint number associated with the most recently captured SETUP packet."]
 pub type EPNO_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:3 - The number of the endpoint associated with the current SETUP packet."]
+    #[doc = "Bits 0:3 - The endpoint number associated with the most recently captured SETUP packet."]
     #[inline(always)]
     pub fn epno(&self) -> EPNO_R {
         EPNO_R::new((self.bits & 0x0f) as u8)

--- a/firmware/lunasoc-pac/src/generated/usb1_ep_control/data.rs
+++ b/firmware/lunasoc-pac/src/generated/usb1_ep_control/data.rs
@@ -1,9 +1,9 @@
 #[doc = "Register `data` reader"]
 pub type R = crate::R<DATA_SPEC>;
-#[doc = "Field `data` reader - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this conain the core SETUP packet."]
+#[doc = "Field `data` reader - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this contain the core SETUP packet."]
 pub type DATA_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:7 - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this conain the core SETUP packet."]
+    #[doc = "Bits 0:7 - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this contain the core SETUP packet."]
     #[inline(always)]
     pub fn data(&self) -> DATA_R {
         DATA_R::new((self.bits & 0xff) as u8)

--- a/firmware/lunasoc-pac/src/generated/usb1_ep_control/epno.rs
+++ b/firmware/lunasoc-pac/src/generated/usb1_ep_control/epno.rs
@@ -1,9 +1,9 @@
 #[doc = "Register `epno` reader"]
 pub type R = crate::R<EPNO_SPEC>;
-#[doc = "Field `epno` reader - The number of the endpoint associated with the current SETUP packet."]
+#[doc = "Field `epno` reader - The endpoint number associated with the most recently captured SETUP packet."]
 pub type EPNO_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:3 - The number of the endpoint associated with the current SETUP packet."]
+    #[doc = "Bits 0:3 - The endpoint number associated with the most recently captured SETUP packet."]
     #[inline(always)]
     pub fn epno(&self) -> EPNO_R {
         EPNO_R::new((self.bits & 0x0f) as u8)

--- a/firmware/lunasoc-pac/src/generated/usb2_ep_control/data.rs
+++ b/firmware/lunasoc-pac/src/generated/usb2_ep_control/data.rs
@@ -1,9 +1,9 @@
 #[doc = "Register `data` reader"]
 pub type R = crate::R<DATA_SPEC>;
-#[doc = "Field `data` reader - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this conain the core SETUP packet."]
+#[doc = "Field `data` reader - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this contain the core SETUP packet."]
 pub type DATA_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:7 - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this conain the core SETUP packet."]
+    #[doc = "Bits 0:7 - A FIFO that returns the bytes from the most recently captured SETUP packet. Reading a byte from this register advances the FIFO. The first eight bytes read from this contain the core SETUP packet."]
     #[inline(always)]
     pub fn data(&self) -> DATA_R {
         DATA_R::new((self.bits & 0xff) as u8)

--- a/firmware/lunasoc-pac/src/generated/usb2_ep_control/epno.rs
+++ b/firmware/lunasoc-pac/src/generated/usb2_ep_control/epno.rs
@@ -1,9 +1,9 @@
 #[doc = "Register `epno` reader"]
 pub type R = crate::R<EPNO_SPEC>;
-#[doc = "Field `epno` reader - The number of the endpoint associated with the current SETUP packet."]
+#[doc = "Field `epno` reader - The endpoint number associated with the most recently captured SETUP packet."]
 pub type EPNO_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:3 - The number of the endpoint associated with the current SETUP packet."]
+    #[doc = "Bits 0:3 - The endpoint number associated with the most recently captured SETUP packet."]
     #[inline(always)]
     pub fn epno(&self) -> EPNO_R {
         EPNO_R::new((self.bits & 0x0f) as u8)

--- a/firmware/lunasoc-pac/svd/lunasoc.svd
+++ b/firmware/lunasoc-pac/svd/lunasoc.svd
@@ -663,7 +663,7 @@
               <description>
             A FIFO that returns the bytes from the most recently captured SETUP packet.
             Reading a byte from this register advances the FIFO. The first eight bytes read
-            from this conain the core SETUP packet.
+            from this contain the core SETUP packet.
         </description>
               <bitRange>[7:0]</bitRange>
             </field>
@@ -696,7 +696,7 @@
           <fields>
             <field>
               <name>epno</name>
-              <description>The number of the endpoint associated with the current SETUP packet.</description>
+              <description>The endpoint number associated with the most recently captured SETUP packet.</description>
               <bitRange>[3:0]</bitRange>
             </field>
           </fields>
@@ -1428,7 +1428,7 @@
               <description>
             A FIFO that returns the bytes from the most recently captured SETUP packet.
             Reading a byte from this register advances the FIFO. The first eight bytes read
-            from this conain the core SETUP packet.
+            from this contain the core SETUP packet.
         </description>
               <bitRange>[7:0]</bitRange>
             </field>
@@ -1461,7 +1461,7 @@
           <fields>
             <field>
               <name>epno</name>
-              <description>The number of the endpoint associated with the current SETUP packet.</description>
+              <description>The endpoint number associated with the most recently captured SETUP packet.</description>
               <bitRange>[3:0]</bitRange>
             </field>
           </fields>
@@ -2193,7 +2193,7 @@
               <description>
             A FIFO that returns the bytes from the most recently captured SETUP packet.
             Reading a byte from this register advances the FIFO. The first eight bytes read
-            from this conain the core SETUP packet.
+            from this contain the core SETUP packet.
         </description>
               <bitRange>[7:0]</bitRange>
             </field>
@@ -2226,7 +2226,7 @@
           <fields>
             <field>
               <name>epno</name>
-              <description>The number of the endpoint associated with the current SETUP packet.</description>
+              <description>The endpoint number associated with the most recently captured SETUP packet.</description>
               <bitRange>[3:0]</bitRange>
             </field>
           </fields>
@@ -2795,6 +2795,186 @@
             <field>
               <name>enable</name>
               <description>usb2_ep_out enable register field</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>UART1</name>
+      <groupName>UART1</groupName>
+      <baseAddress>0xf0006000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>uart1</name>
+        <value>16</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>divisor</name>
+          <description>uart1 divisor register</description>
+          <addressOffset>0x0000</addressOffset>
+          <size>32</size>
+          <resetValue>0x00</resetValue>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>divisor</name>
+              <description>uart1 divisor register field</description>
+              <bitRange>[9:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rx_data</name>
+          <description>uart1 rx_data register</description>
+          <addressOffset>0x0004</addressOffset>
+          <size>32</size>
+          <resetValue>0x00</resetValue>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>rx_data</name>
+              <description>uart1 rx_data register field</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rx_rdy</name>
+          <description>uart1 rx_rdy register</description>
+          <addressOffset>0x0008</addressOffset>
+          <size>32</size>
+          <resetValue>0x00</resetValue>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>rx_rdy</name>
+              <description>uart1 rx_rdy register field</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rx_err</name>
+          <description>uart1 rx_err register</description>
+          <addressOffset>0x000c</addressOffset>
+          <size>32</size>
+          <resetValue>0x00</resetValue>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>rx_err</name>
+              <description>uart1 rx_err register field</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_data</name>
+          <description>uart1 tx_data register</description>
+          <addressOffset>0x0010</addressOffset>
+          <size>32</size>
+          <resetValue>0x00</resetValue>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>tx_data</name>
+              <description>uart1 tx_data register field</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_rdy</name>
+          <description>uart1 tx_rdy register</description>
+          <addressOffset>0x0014</addressOffset>
+          <size>32</size>
+          <resetValue>0x00</resetValue>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>tx_rdy</name>
+              <description>uart1 tx_rdy register field</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ev_status</name>
+          <description>uart1 ev_status register</description>
+          <addressOffset>0x0020</addressOffset>
+          <size>32</size>
+          <resetValue>0x00</resetValue>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>status</name>
+              <description>uart1 status register field</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ev_pending</name>
+          <description>uart1 ev_pending register</description>
+          <addressOffset>0x0024</addressOffset>
+          <size>32</size>
+          <resetValue>0x00</resetValue>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>pending</name>
+              <description>uart1 pending register field</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ev_enable</name>
+          <description>uart1 ev_enable register</description>
+          <addressOffset>0x0028</addressOffset>
+          <size>32</size>
+          <resetValue>0x00</resetValue>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description>uart1 enable register field</description>
+              <bitRange>[2:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>ADVERTISER</name>
+      <groupName>ADVERTISER</groupName>
+      <baseAddress>0xf0007000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x08</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>enable</name>
+          <description>advertiser enable register</description>
+          <addressOffset>0x0000</addressOffset>
+          <size>32</size>
+          <resetValue>0x00</resetValue>
+          <access>read-write</access>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description>
+            Set this bit to '1' to start ApolloAdvertiser and disconnect the Cynthion USB control port from Apollo.
+        </description>
               <bitRange>[0:0]</bitRange>
             </field>
           </fields>

--- a/firmware/moondancer/README.md
+++ b/firmware/moondancer/README.md
@@ -1,3 +1,50 @@
 # moondancer
 
 MoonDancer firmware for the Great Scott Gadgets Cynthion.
+
+
+
+
+## debug support
+
+The moondancer SoC exposes UART and JTAG ports on Cynthion's PMOD B port:
+
+    Pin 1:  UART1 rx
+    Pin 2:  UART1 rx
+
+    Pin 7:  JTAG tms
+    Pin 8:  JTAG tdi
+    Pin 9:  JTAG tdo
+    Pin 10: JTAG tck
+
+
+### UART
+
+The Cynthion SoC provides two UART ports.
+
+UART0 is connected to the Cynthion SAMD11 microcontroller and can only be accessed if the SoC firmware does not make use of the Cynthion's Control port (USB0).
+
+UART1 is connected to the Cynthion's PMOD B port and be accessed via a serial adapter.
+
+    picocom --imap lfcrlf -b 115200 /dev/cu.usbserial-1301
+
+
+### JTAG
+
+The Cynthion SoC provides a JTAG port connected to the Vexriscv processor.
+
+It is connected to the Cynthion's PMOD B port and can be used to load firmware and debug the CPU.
+
+#### Load firmware
+
+    openocd -f openocd-jtag+serial.cfg -f flash.cfg
+
+#### Debug firmware
+
+Terminal 2:
+
+    openocd -f openocd-jtag+serial.cfg
+
+Terminal 3:
+
+    cargo run --release

--- a/firmware/moondancer/README.md
+++ b/firmware/moondancer/README.md
@@ -48,3 +48,17 @@ Terminal 2:
 Terminal 3:
 
     cargo run --release
+
+
+## Cynthion USB2 Control Port
+
+By default the Cynthion USB2 Control port is managed by Apollo.
+
+If you would like to take over control from apollo and use USB2 in your own firmware you can disable the ApolloAdvertiser peripheral using something like:
+
+    let peripherals = pac::Peripherals::take().unwrap();
+
+    let advertiser = peripherals.ADVERTISER;
+    advertiser.enable().write(|w| w.enable().bit(true));
+
+Note that you will no longer be able to receive UART0 data via Apollo in this case and will need to use UART1 instead.

--- a/firmware/moondancer/src/bin/cdc_serial_loopback.rs
+++ b/firmware/moondancer/src/bin/cdc_serial_loopback.rs
@@ -162,8 +162,7 @@ fn main() -> ! {
     leds.output().write(|w| unsafe { w.output().bits(0x0) });
 
     // initialize logging
-    let serial = hal::Serial::new(peripherals.UART);
-    moondancer::log::init(serial);
+    moondancer::log::init();
     info!("logging initialized");
 
     // usb0: Target

--- a/firmware/moondancer/src/bin/gpio.rs
+++ b/firmware/moondancer/src/bin/gpio.rs
@@ -4,8 +4,6 @@
 use moondancer::pac;
 
 use hal::hal::delay::DelayUs;
-use hal::Serial;
-use hal::Timer;
 use moondancer::hal;
 
 use log::{error, info};
@@ -40,8 +38,7 @@ fn main() -> ! {
     let leds = &peripherals.LEDS;
 
     // initialize logging
-    let serial = Serial::new(peripherals.UART);
-    moondancer::log::init(serial);
+    moondancer::log::init();
 
     // configure gpioa pins 7-4:output, 3-0:input
     let gpioa = &peripherals.GPIOA;
@@ -53,7 +50,7 @@ fn main() -> ! {
     gpioa.ev_enable().write(|w| w.enable().bit(true));
 
     // configure and enable timer
-    let mut timer = Timer::new(peripherals.TIMER, pac::clock::sysclk());
+    let mut timer = hal::Timer0::new(peripherals.TIMER, pac::clock::sysclk());
 
     // enable interrupts
     unsafe {

--- a/firmware/moondancer/src/bin/hello.rs
+++ b/firmware/moondancer/src/bin/hello.rs
@@ -4,8 +4,6 @@
 use moondancer::pac;
 
 use hal::hal::delay::DelayUs;
-use hal::Serial;
-use hal::Timer;
 use moondancer::hal;
 
 use log::{debug, info};
@@ -26,10 +24,9 @@ fn main() -> ! {
     let leds = &peripherals.LEDS;
 
     // initialize logging
-    let serial = Serial::new(peripherals.UART);
-    moondancer::log::init(serial);
+    moondancer::log::init();
 
-    let mut timer = Timer::new(peripherals.TIMER, pac::clock::sysclk());
+    let mut timer = hal::Timer0::new(peripherals.TIMER, pac::clock::sysclk());
     let mut counter = 0;
     let mut direction = true;
     let mut led_state = 0b11_0000;

--- a/firmware/moondancer/src/bin/interrupts.rs
+++ b/firmware/moondancer/src/bin/interrupts.rs
@@ -14,7 +14,7 @@ extern "C" fn MachineExternal() {
     static mut TOGGLE: bool = true;
 
     if pac::csr::interrupt::pending(pac::Interrupt::TIMER) {
-        let timer = unsafe { hal::Timer::summon() };
+        let timer = unsafe { hal::Timer0::summon() };
         timer.clear_pending();
 
         //writeln!(serial, "MachineExternal - timer interrupt").unwrap();
@@ -39,12 +39,13 @@ extern "C" fn MachineExternal() {
 #[entry]
 fn main() -> ! {
     let peripherals = pac::Peripherals::take().unwrap();
-    let serial = hal::Serial::new(peripherals.UART);
-    moondancer::log::init(serial);
+
+    // initialize logging
+    moondancer::log::init();
 
     // configure and enable timer
     let one_second = pac::clock::sysclk();
-    let mut timer = hal::Timer::new(peripherals.TIMER, one_second);
+    let mut timer = hal::Timer0::new(peripherals.TIMER, one_second);
     timer.set_timeout_ticks(one_second / 2);
     timer.enable();
 

--- a/firmware/moondancer/src/bin/moondancer.rs
+++ b/firmware/moondancer/src/bin/moondancer.rs
@@ -117,8 +117,13 @@ impl<'a> Firmware<'a> {
         ];
         let classes = libgreat::gcp::Classes(&CLASSES);
 
+        // enable ApolloAdvertiser to disconnect the Cynthion USB2 control port from Apollo
+        let advertiser = peripherals.ADVERTISER;
+        advertiser.enable().write(|w| w.enable().bit(true));
+
         // initialize logging
-        moondancer::log::init(hal::Serial::new(peripherals.UART));
+        moondancer::log::set_port(moondancer::log::Port::Uart1);
+        moondancer::log::init();
         info!(
             "{} {}",
             cynthion::shared::usb::bManufacturerString::cynthion,

--- a/firmware/moondancer/src/bin/usb_hal.rs
+++ b/firmware/moondancer/src/bin/usb_hal.rs
@@ -169,7 +169,7 @@ fn main_loop() -> GreatResult<()> {
     let peripherals = pac::Peripherals::take().unwrap();
 
     // initialize logging
-    moondancer::log::init(hal::Serial::new(peripherals.UART));
+    moondancer::log::init();
     info!("Logging initialized");
 
     // usb0: Target

--- a/firmware/moondancer/src/debug.rs
+++ b/firmware/moondancer/src/debug.rs
@@ -6,7 +6,7 @@ use crate::pac;
 pub fn init(_gpioa: pac::GPIOA, _gpiob: pac::GPIOB) {
     #[cfg(feature = "ladybug")]
     unsafe {
-        use crate::debug::ladybug_impl::{LADYBUG_CYNTHION, LadybugCynthion};
+        use crate::debug::ladybug_impl::{LadybugCynthion, LADYBUG_CYNTHION};
         LADYBUG_CYNTHION = Some(LadybugCynthion::new(_gpioa, _gpiob));
         ladybug::set_analyzer(LADYBUG_CYNTHION.as_ref().expect("surprises"));
     }

--- a/firmware/moondancer/src/gcp/moondancer.rs
+++ b/firmware/moondancer/src/gcp/moondancer.rs
@@ -488,9 +488,7 @@ impl Moondancer {
             .iter()
             .position(|packet| packet.endpoint_number == endpoint_number)
         {
-            Some(index) => {
-                self.packet_buffer.remove(index)
-            }
+            Some(index) => self.packet_buffer.remove(index),
             None => {
                 error!(
                     "MD moondancer::read_endpoint({}) has no packet buffered for endpoint",
@@ -500,7 +498,6 @@ impl Moondancer {
                 Packet::new(endpoint_number, 0)
             }
         };
-
 
         log::debug!(
             "MD moondancer::read_endpoint({}) -> bytes_read:{}",

--- a/firmware/moondancer/test/test_moondancer.py
+++ b/firmware/moondancer/test/test_moondancer.py
@@ -44,7 +44,7 @@ class TestMoondancer(unittest.TestCase):
         self.assertEqual(len(response), 4)
 
         # test known values for each item
-        response = list(map(InterruptEvent.parse, response))
+        response = list(map(InterruptEvent, response))
         self.assertEqual(response[0], InterruptEvent.USB_BUS_RESET)
         self.assertEqual(response[0].endpoint_number, 0)
         self.assertEqual(response[1], InterruptEvent.USB_RECEIVE_CONTROL)


### PR DESCRIPTION
This PR makes some fundamental changes to the moondancer soc and firmware:

* Adds a second UART to Cynthion's PMOD B port
* Adds a JTAG interface to Cynthion's PMOD B port
* Moves moondancer firmware to Cynthion's control port
* Adds support for using `ApolloAdvertiser` to claim the Control port from Apollo in firmware.

### Notes

* Currently relies on a patched version of `ApolloAdvertiser` that allows overriding the advertiser timer's clock frequency so we can run it off the 60MHz `usb` domain.
* There's a weirdness with `ApolloAdvertiser` where, if the advertiser is not running at gateware start, subsequently enabling it does not result in the control port being released by Apollo.

