### PR TITLE
Add resources for single-ended use of D+/D- sense pins

### DIFF
--- a/cynthion/python/src/gateware/platform/cynthion_r0_6.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_6.py
@@ -96,6 +96,8 @@ class CynthionPlatformRev0D6(CynthionPlatform):
 
         # direct connection to TARGET USB D+/D-
         Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+        Resource("target_usb_dp", 0, Pins("N4", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
+        Resource("target_usb_dm", 0, Pins("P3", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
 
         # USB Type-C controllers and pins
         Resource("target_type_c", 0,

--- a/cynthion/python/src/gateware/platform/cynthion_r0_7.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_7.py
@@ -96,6 +96,8 @@ class CynthionPlatformRev0D7(CynthionPlatform):
 
         # direct connection to TARGET USB D+/D-
         Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+        Resource("target_usb_dp", 0, Pins("N4", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
+        Resource("target_usb_dm", 0, Pins("P3", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
 
         # USB Type-C controllers and pins
         Resource("target_type_c", 0,

--- a/cynthion/python/src/gateware/platform/cynthion_r1_0.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_0.py
@@ -96,6 +96,8 @@ class CynthionPlatformRev1D0(CynthionPlatform):
 
         # direct connection to TARGET USB D+/D-
         Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+        Resource("target_usb_dp", 0, Pins("N4", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
+        Resource("target_usb_dm", 0, Pins("P3", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
 
         # USB Type-C controllers and pins
         Resource("target_type_c", 0,

--- a/cynthion/python/src/gateware/platform/cynthion_r1_1.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_1.py
@@ -96,6 +96,8 @@ class CynthionPlatformRev1D1(CynthionPlatform):
 
         # direct connection to TARGET USB D+/D-
         Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+        Resource("target_usb_dp", 0, Pins("N4", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
+        Resource("target_usb_dm", 0, Pins("P3", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
 
         # USB Type-C controllers and pins
         Resource("target_type_c", 0,

--- a/cynthion/python/src/gateware/platform/cynthion_r1_2.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_2.py
@@ -108,6 +108,8 @@ class CynthionPlatformRev1D2(CynthionPlatform):
 
         # direct connection to TARGET USB D+/D-
         Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+        Resource("target_usb_dp", 0, Pins("N4", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
+        Resource("target_usb_dm", 0, Pins("P3", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
 
         # USB Type-C controllers and pins
         Resource("target_type_c", 0,

--- a/cynthion/python/src/gateware/platform/cynthion_r1_3.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_3.py
@@ -108,6 +108,8 @@ class CynthionPlatformRev1D3(CynthionPlatform):
 
         # direct connection to TARGET USB D+/D-
         Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+        Resource("target_usb_dp", 0, Pins("N4", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
+        Resource("target_usb_dm", 0, Pins("P3", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
 
         # USB Type-C controllers and pins
         Resource("target_type_c", 0,

--- a/cynthion/python/src/gateware/platform/cynthion_r1_4.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_4.py
@@ -108,6 +108,8 @@ class CynthionPlatformRev1D4(CynthionPlatform):
 
         # direct connection to TARGET USB D+/D-
         Resource("target_usb_diff", 0, DiffPairs("N4", "P3", dir="i"), Attrs(IO_TYPE="LVDS", PULLMODE="NONE")),
+        Resource("target_usb_dp", 0, Pins("N4", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
+        Resource("target_usb_dm", 0, Pins("P3", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")),
 
         # USB Type-C controllers and pins
         Resource("target_type_c", 0,


### PR DESCRIPTION
Needed for the factory test, which has to drive these pins individually from the PHY to ensure they're connected and not shorted to each other.