### PR TITLE
Update zerocopy to 0.7.34

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -72,6 +72,9 @@ Install a RISC-V GNU toolchain so we can use gdb for firmware debugging over JTA
     # debian
     apt install gcc-riscv64-unknown-elf
 
+    # arch
+    pacman -S riscv-gnu-toolchain-bin
+
     # macos brew - https://github.com/riscv-software-src/homebrew-riscv
     brew tap riscv-software-src/riscv
     brew install riscv-gnu-toolchain

--- a/cynthion/python/src/gateware/soc/top.py
+++ b/cynthion/python/src/gateware/soc/top.py
@@ -159,7 +159,7 @@ class MoondancerSoc(Elaboratable):
             user1_io = platform.request("button_user")
             m.d.comb += self.soc.cpu.ext_reset.eq(user1_io.i)
         except:
-            logging.warn("Platform does not support a user button for cpu reset")
+            logging.warning("Platform does not support a user button for cpu reset")
 
         # add the spi bus
         m.submodules.spi_bus = self.spi_bus

--- a/firmware/libgreat-rs/Cargo.toml
+++ b/firmware/libgreat-rs/Cargo.toml
@@ -20,4 +20,4 @@ errno_minimal = []
 
 [dependencies]
 log = "=0.4.17"
-zerocopy = { version = "=0.7.0-alpha.2", default-features = false }
+zerocopy = { version = "0.7.34", default-features = false, features = ["derive", "byteorder"] }

--- a/firmware/libgreat-rs/src/gcp/class.rs
+++ b/firmware/libgreat-rs/src/gcp/class.rs
@@ -1,6 +1,6 @@
 //! Great Communications Protocol Class Registry
 
-use zerocopy::{LittleEndian, U32};
+use zerocopy::byteorder::{LittleEndian, U32};
 
 // - Classes ------------------------------------------------------------------
 

--- a/firmware/libgreat-rs/src/gcp/class_core.rs
+++ b/firmware/libgreat-rs/src/gcp/class_core.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 
-use zerocopy::{FromBytes, LittleEndian, Unaligned, U32};
+use zerocopy::byteorder::{LittleEndian, U32};
+use zerocopy::{FromBytes, FromZeroes, Unaligned};
 
 use crate::error::{GreatError, GreatResult};
 use crate::firmware::BoardInformation;
@@ -179,7 +180,7 @@ impl Core {
 
     pub fn get_available_verbs(&self, arguments: &[u8]) -> GreatResult<impl Iterator<Item = u8>> {
         #[repr(C)]
-        #[derive(FromBytes, Unaligned)]
+        #[derive(FromBytes, FromZeroes, Unaligned)]
         struct Args {
             class_number: U32<LittleEndian>,
         }
@@ -195,7 +196,7 @@ impl Core {
 
     pub fn get_verb_name(&self, arguments: &[u8]) -> GreatResult<impl Iterator<Item = u8>> {
         #[repr(C)]
-        #[derive(FromBytes, Unaligned)]
+        #[derive(FromBytes, FromZeroes, Unaligned)]
         struct Args {
             class_number: U32<LittleEndian>,
             verb_number: U32<LittleEndian>,
@@ -214,7 +215,7 @@ impl Core {
 
     pub fn get_verb_descriptor(&self, arguments: &[u8]) -> GreatResult<impl Iterator<Item = u8>> {
         #[repr(C)]
-        #[derive(Debug, FromBytes, Unaligned)]
+        #[derive(FromBytes, FromZeroes, Unaligned)]
         struct Args {
             class_number: U32<LittleEndian>,
             verb_number: U32<LittleEndian>,
@@ -241,7 +242,7 @@ impl Core {
 
     pub fn get_class_name(&self, arguments: &[u8]) -> GreatResult<impl Iterator<Item = u8>> {
         #[repr(C)]
-        #[derive(FromBytes, Unaligned)]
+        #[derive(FromBytes, FromZeroes, Unaligned)]
         struct Args {
             class_number: U32<LittleEndian>,
         }
@@ -256,7 +257,7 @@ impl Core {
 
     pub fn get_class_docs(&self, arguments: &[u8]) -> GreatResult<impl Iterator<Item = u8>> {
         #[repr(C)]
-        #[derive(FromBytes, Unaligned)]
+        #[derive(FromBytes, FromZeroes, Unaligned)]
         struct Args {
             class_number: U32<LittleEndian>,
         }

--- a/firmware/lunasoc-pac/src/generated/gpioa/idr.rs
+++ b/firmware/lunasoc-pac/src/generated/gpioa/idr.rs
@@ -1,9 +1,9 @@
 #[doc = "Register `idr` reader"]
 pub type R = crate::R<IDR_SPEC>;
-#[doc = "Field `idr` reader - gpioa idr register field"]
+#[doc = "Field `idr` reader - "]
 pub type IDR_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:7 - gpioa idr register field"]
+    #[doc = "Bits 0:7"]
     #[inline(always)]
     pub fn idr(&self) -> IDR_R {
         IDR_R::new((self.bits & 0xff) as u8)

--- a/firmware/lunasoc-pac/src/generated/gpioa/moder.rs
+++ b/firmware/lunasoc-pac/src/generated/gpioa/moder.rs
@@ -2,19 +2,19 @@
 pub type R = crate::R<MODER_SPEC>;
 #[doc = "Register `moder` writer"]
 pub type W = crate::W<MODER_SPEC>;
-#[doc = "Field `moder` reader - gpioa moder register field"]
+#[doc = "Field `moder` reader - "]
 pub type MODER_R = crate::FieldReader;
-#[doc = "Field `moder` writer - gpioa moder register field"]
+#[doc = "Field `moder` writer - "]
 pub type MODER_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
 impl R {
-    #[doc = "Bits 0:7 - gpioa moder register field"]
+    #[doc = "Bits 0:7"]
     #[inline(always)]
     pub fn moder(&self) -> MODER_R {
         MODER_R::new((self.bits & 0xff) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:7 - gpioa moder register field"]
+    #[doc = "Bits 0:7"]
     #[inline(always)]
     #[must_use]
     pub fn moder(&mut self) -> MODER_W<MODER_SPEC> {

--- a/firmware/lunasoc-pac/src/generated/gpioa/odr.rs
+++ b/firmware/lunasoc-pac/src/generated/gpioa/odr.rs
@@ -1,9 +1,9 @@
 #[doc = "Register `odr` writer"]
 pub type W = crate::W<ODR_SPEC>;
-#[doc = "Field `odr` writer - gpioa odr register field"]
+#[doc = "Field `odr` writer - "]
 pub type ODR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
 impl W {
-    #[doc = "Bits 0:7 - gpioa odr register field"]
+    #[doc = "Bits 0:7"]
     #[inline(always)]
     #[must_use]
     pub fn odr(&mut self) -> ODR_W<ODR_SPEC> {

--- a/firmware/lunasoc-pac/src/generated/gpiob/idr.rs
+++ b/firmware/lunasoc-pac/src/generated/gpiob/idr.rs
@@ -1,9 +1,9 @@
 #[doc = "Register `idr` reader"]
 pub type R = crate::R<IDR_SPEC>;
-#[doc = "Field `idr` reader - gpiob idr register field"]
+#[doc = "Field `idr` reader - "]
 pub type IDR_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:7 - gpiob idr register field"]
+    #[doc = "Bits 0:7"]
     #[inline(always)]
     pub fn idr(&self) -> IDR_R {
         IDR_R::new((self.bits & 0xff) as u8)

--- a/firmware/lunasoc-pac/src/generated/gpiob/moder.rs
+++ b/firmware/lunasoc-pac/src/generated/gpiob/moder.rs
@@ -2,19 +2,19 @@
 pub type R = crate::R<MODER_SPEC>;
 #[doc = "Register `moder` writer"]
 pub type W = crate::W<MODER_SPEC>;
-#[doc = "Field `moder` reader - gpiob moder register field"]
+#[doc = "Field `moder` reader - "]
 pub type MODER_R = crate::FieldReader;
-#[doc = "Field `moder` writer - gpiob moder register field"]
+#[doc = "Field `moder` writer - "]
 pub type MODER_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
 impl R {
-    #[doc = "Bits 0:7 - gpiob moder register field"]
+    #[doc = "Bits 0:7"]
     #[inline(always)]
     pub fn moder(&self) -> MODER_R {
         MODER_R::new((self.bits & 0xff) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:7 - gpiob moder register field"]
+    #[doc = "Bits 0:7"]
     #[inline(always)]
     #[must_use]
     pub fn moder(&mut self) -> MODER_W<MODER_SPEC> {

--- a/firmware/lunasoc-pac/src/generated/gpiob/odr.rs
+++ b/firmware/lunasoc-pac/src/generated/gpiob/odr.rs
@@ -1,9 +1,9 @@
 #[doc = "Register `odr` writer"]
 pub type W = crate::W<ODR_SPEC>;
-#[doc = "Field `odr` writer - gpiob odr register field"]
+#[doc = "Field `odr` writer - "]
 pub type ODR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
 impl W {
-    #[doc = "Bits 0:7 - gpiob odr register field"]
+    #[doc = "Bits 0:7"]
     #[inline(always)]
     #[must_use]
     pub fn odr(&mut self) -> ODR_W<ODR_SPEC> {

--- a/firmware/lunasoc-pac/src/generated/leds/output.rs
+++ b/firmware/lunasoc-pac/src/generated/leds/output.rs
@@ -1,9 +1,9 @@
 #[doc = "Register `output` writer"]
 pub type W = crate::W<OUTPUT_SPEC>;
-#[doc = "Field `output` writer - leds output register field"]
+#[doc = "Field `output` writer - "]
 pub type OUTPUT_W<'a, REG> = crate::FieldWriter<'a, REG, 6>;
 impl W {
-    #[doc = "Bits 0:5 - leds output register field"]
+    #[doc = "Bits 0:5"]
     #[inline(always)]
     #[must_use]
     pub fn output(&mut self) -> OUTPUT_W<OUTPUT_SPEC> {

--- a/firmware/lunasoc-pac/svd/lunasoc.svd
+++ b/firmware/lunasoc-pac/svd/lunasoc.svd
@@ -287,7 +287,7 @@
           <fields>
             <field>
               <name>output</name>
-              <description>leds output register field</description>
+              <description/>
               <bitRange>[5:0]</bitRange>
             </field>
           </fields>
@@ -318,7 +318,7 @@
           <fields>
             <field>
               <name>moder</name>
-              <description>gpioa moder register field</description>
+              <description/>
               <bitRange>[7:0]</bitRange>
             </field>
           </fields>
@@ -333,7 +333,7 @@
           <fields>
             <field>
               <name>odr</name>
-              <description>gpioa odr register field</description>
+              <description/>
               <bitRange>[7:0]</bitRange>
             </field>
           </fields>
@@ -348,7 +348,7 @@
           <fields>
             <field>
               <name>idr</name>
-              <description>gpioa idr register field</description>
+              <description/>
               <bitRange>[7:0]</bitRange>
             </field>
           </fields>
@@ -424,7 +424,7 @@
           <fields>
             <field>
               <name>moder</name>
-              <description>gpiob moder register field</description>
+              <description/>
               <bitRange>[7:0]</bitRange>
             </field>
           </fields>
@@ -439,7 +439,7 @@
           <fields>
             <field>
               <name>odr</name>
-              <description>gpiob odr register field</description>
+              <description/>
               <bitRange>[7:0]</bitRange>
             </field>
           </fields>
@@ -454,7 +454,7 @@
           <fields>
             <field>
               <name>idr</name>
-              <description>gpiob idr register field</description>
+              <description/>
               <bitRange>[7:0]</bitRange>
             </field>
           </fields>
@@ -2987,17 +2987,17 @@
       <memoryRegion>
         <name>BOOTROM</name>
         <baseAddress>0x00000000</baseAddress>
-        <size>0x00004000</size>
-      </memoryRegion>
-      <memoryRegion>
-        <name>SCRATCHPAD</name>
-        <baseAddress>0x10000000</baseAddress>
-        <size>0x00001000</size>
+        <size>0x00000020</size>
       </memoryRegion>
       <memoryRegion>
         <name>MAINRAM</name>
         <baseAddress>0x40000000</baseAddress>
         <size>0x00010000</size>
+      </memoryRegion>
+      <memoryRegion>
+        <name>SPIFLASH</name>
+        <baseAddress>0x10000000</baseAddress>
+        <size>0x00400000</size>
       </memoryRegion>
     </memoryRegions>
     <constants/>

--- a/firmware/moondancer/Cargo.toml
+++ b/firmware/moondancer/Cargo.toml
@@ -78,7 +78,7 @@ riscv-rt = { version = "=0.11.0" }
 bbqueue = { version = "0.5.1", default-features = false }
 
 heapless = { version = "=0.7.16", default-features = false, features = ["cas", "mpmc_large"] }
-zerocopy = { version = "=0.7.0-alpha.2", default-features = false }
+zerocopy = { version = "0.7.34", default-features = false, features = ["derive", "byteorder"] }
 
 log = { version="=0.4.17", features = ["release_max_level_info"] }
 

--- a/firmware/moondancer/src/bin/moondancer.rs
+++ b/firmware/moondancer/src/bin/moondancer.rs
@@ -122,7 +122,7 @@ impl<'a> Firmware<'a> {
         advertiser.enable().write(|w| w.enable().bit(true));
 
         // initialize logging
-        moondancer::log::set_port(moondancer::log::Port::Uart1);
+        moondancer::log::set_port(moondancer::log::Port::Both);
         moondancer::log::init();
         info!(
             "{} {}",

--- a/firmware/moondancer/src/gcp/firmware.rs
+++ b/firmware/moondancer/src/gcp/firmware.rs
@@ -1,7 +1,8 @@
 use libgreat::error::{GreatError, GreatResult};
 use libgreat::gcp::{self, Verb};
 
-use zerocopy::{FromBytes, LittleEndian, Unaligned, U32};
+use zerocopy::byteorder::{LittleEndian, U32};
+use zerocopy::{FromBytes, FromZeroes, Unaligned};
 
 use core::any::Any;
 
@@ -91,7 +92,7 @@ pub fn page_erase<'a>(
     _context: &'a dyn Any,
 ) -> GreatResult<impl Iterator<Item = u8> + 'a> {
     #[repr(C)]
-    #[derive(FromBytes, Unaligned)]
+    #[derive(FromBytes, FromZeroes, Unaligned)]
     struct Args {
         address: U32<LittleEndian>,
     }
@@ -104,11 +105,11 @@ pub fn write_page<'a>(
     _context: &'a dyn Any,
 ) -> GreatResult<impl Iterator<Item = u8> + 'a> {
     struct Args<B: zerocopy::ByteSlice> {
-        _address: zerocopy::LayoutVerified<B, U32<LittleEndian>>,
+        _address: zerocopy::Ref<B, U32<LittleEndian>>,
         _data: B,
     }
-    let (_address, _data) = zerocopy::LayoutVerified::new_unaligned_from_prefix(arguments)
-        .ok_or(GreatError::InvalidArgument)?;
+    let (_address, _data) =
+        zerocopy::Ref::new_unaligned_from_prefix(arguments).ok_or(GreatError::InvalidArgument)?;
     let _args = Args { _address, _data };
     Ok([].into_iter())
 }
@@ -118,7 +119,7 @@ pub fn read_page<'a>(
     _context: &'a dyn Any,
 ) -> GreatResult<impl Iterator<Item = u8> + 'a> {
     #[repr(C)]
-    #[derive(FromBytes, Unaligned)]
+    #[derive(FromBytes, FromZeroes, Unaligned)]
     struct Args {
         address: U32<LittleEndian>,
     }

--- a/firmware/moondancer/src/gcp/selftest.rs
+++ b/firmware/moondancer/src/gcp/selftest.rs
@@ -2,7 +2,7 @@ use libgreat::error::{GreatError, GreatResult};
 use libgreat::gcp::{self, Verb};
 
 use log::debug;
-use zerocopy::{FromBytes, LittleEndian, Unaligned, U32};
+use zerocopy::{FromBytes, FromZeroes, LittleEndian, Unaligned, U32};
 
 use core::any::Any;
 
@@ -34,7 +34,7 @@ pub fn test_error_return_code<'a>(
     _context: &'a dyn Any,
 ) -> GreatResult<impl Iterator<Item = u8> + 'a> {
     #[repr(C)]
-    #[derive(FromBytes, Unaligned)]
+    #[derive(FromBytes, FromZeroes, Unaligned)]
     struct Args {
         code: U32<LittleEndian>,
     }

--- a/firmware/moondancer/src/log.rs
+++ b/firmware/moondancer/src/log.rs
@@ -55,7 +55,7 @@ pub fn set_port(port: Port) {
 pub enum Port {
     Uart0,
     Uart1,
-    Both
+    Both,
 }
 
 /// Logger for objects implementing [`Write`] and [`Send`].

--- a/firmware/smolusb/Cargo.toml
+++ b/firmware/smolusb/Cargo.toml
@@ -24,4 +24,4 @@ nightly = []
 [dependencies]
 heapless = { version = "=0.7.16" }
 log = "=0.4.17"
-zerocopy = { version = "=0.7.0-alpha.2", default-features = false }
+zerocopy = { version = "0.7.34", default-features = false, features = ["derive"] }

--- a/firmware/smolusb/src/descriptor.rs
+++ b/firmware/smolusb/src/descriptor.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use core::mem::size_of;
 use core::slice;
 
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 use crate::traits::AsByteSliceIterator;
 
@@ -63,7 +63,8 @@ impl From<u8> for DescriptorType {
 // - DeviceDescriptor ---------------------------------------------------------
 
 /// USB device descriptor
-#[derive(AsBytes, FromBytes, Clone, Copy)]
+#[allow(clippy::pub_underscore_fields)]
+#[derive(AsBytes, FromBytes, FromZeroes, Clone, Copy)]
 #[repr(C, packed)]
 pub struct DeviceDescriptor {
     pub _length: u8,             // 18
@@ -116,7 +117,8 @@ impl Default for DeviceDescriptor {
 // - DeviceQualifierDescriptor ------------------------------------------------
 
 /// USB device qualifier descriptor
-#[derive(AsBytes, FromBytes, Clone, Copy)]
+#[allow(clippy::pub_underscore_fields)]
+#[derive(AsBytes, FromBytes, FromZeroes, Clone, Copy)]
 #[repr(C, packed)]
 pub struct DeviceQualifierDescriptor {
     pub _length: u8,          // 10
@@ -159,7 +161,8 @@ impl Default for DeviceQualifierDescriptor {
 // - ConfigurationDescriptor --------------------------------------------------
 
 /// USB configuration descriptor header
-#[derive(AsBytes, FromBytes, Clone, Copy)]
+#[allow(clippy::pub_underscore_fields)]
+#[derive(AsBytes, FromBytes, FromZeroes, Clone, Copy)]
 #[repr(C, packed)]
 pub struct ConfigurationDescriptorHeader {
     pub _length: u8,         // 9
@@ -273,7 +276,8 @@ pub type ConfigurationDescriptorTailIterator<'a> = iter::FlatMap<
 // - InterfaceDescriptor ------------------------------------------------------
 
 /// USB interface descriptor header
-#[derive(AsBytes, FromBytes, Clone, Copy)]
+#[allow(clippy::pub_underscore_fields)]
+#[derive(AsBytes, FromBytes, FromZeroes, Clone, Copy)]
 #[repr(C, packed)]
 pub struct InterfaceDescriptorHeader {
     pub _length: u8,          // 9
@@ -333,7 +337,8 @@ impl<'a> InterfaceDescriptor<'a> {
 // - EndpointDescriptor -------------------------------------------------------
 
 /// USB endpoint descriptor
-#[derive(AsBytes, FromBytes, Clone, Copy)]
+#[allow(clippy::pub_underscore_fields)]
+#[derive(AsBytes, FromBytes, FromZeroes, Clone, Copy)]
 #[repr(C, packed)]
 pub struct EndpointDescriptor {
     pub _length: u8,          // 7
@@ -414,7 +419,8 @@ impl<'a> StringDescriptorZero<'a> {
 // - StringDescriptor ---------------------------------------------------------
 
 /// USB string zero descriptor header
-#[derive(AsBytes, FromBytes, Clone, Copy, Debug)]
+#[allow(clippy::pub_underscore_fields)]
+#[derive(AsBytes, FromBytes, FromZeroes, Clone, Copy, Debug)]
 #[repr(C, packed)]
 pub struct StringDescriptorHeader {
     pub _length: u8,


### PR DESCRIPTION
This PR updates zerocopy from `0.7.0-alpha.2` to `0.7.34` and removes the version pin.