### PR TITLE
firmware: update heapless crate to 0.8.0

### DIFF
--- a/firmware/moondancer/Cargo.toml
+++ b/firmware/moondancer/Cargo.toml
@@ -22,7 +22,6 @@ default-run = "moondancer"
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"
 targets = [
-    "riscv32i-unknown-none-elf",
     "riscv32imac-unknown-none-elf",
 ]
 
@@ -75,9 +74,7 @@ smolusb = { path = "../smolusb", default-features = false}
 riscv = { version = "=0.10.1", features = ["critical-section-single-hart"] }
 riscv-rt = { version = "=0.11.0" }
 
-bbqueue = { version = "0.5.1", default-features = false }
-
-heapless = { version = "=0.7.16", default-features = false, features = ["cas", "mpmc_large"] }
+heapless = { version = "0.8.0", default-features = false, features = ["mpmc_large"] }
 zerocopy = { version = "0.7.34", default-features = false, features = ["derive", "byteorder"] }
 
 log = { version="=0.4.17", features = ["release_max_level_info"] }

--- a/firmware/moondancer/src/bin/moondancer.rs
+++ b/firmware/moondancer/src/bin/moondancer.rs
@@ -118,8 +118,9 @@ impl<'a> Firmware<'a> {
         let classes = libgreat::gcp::Classes(&CLASSES);
 
         // enable ApolloAdvertiser to disconnect the Cynthion USB2 control port from Apollo
-        let advertiser = peripherals.ADVERTISER;
-        advertiser.enable().write(|w| w.enable().bit(true));
+        // TODO disable for now until we have a fallback strategy for r0.4
+        //let advertiser = peripherals.ADVERTISER;
+        //advertiser.enable().write(|w| w.enable().bit(true));
 
         // initialize logging
         moondancer::log::set_port(moondancer::log::Port::Both);

--- a/firmware/smolusb/Cargo.toml
+++ b/firmware/smolusb/Cargo.toml
@@ -22,6 +22,5 @@ chonky_events = []
 nightly = []
 
 [dependencies]
-heapless = { version = "=0.7.16" }
 log = "=0.4.17"
 zerocopy = { version = "0.7.34", default-features = false, features = ["derive"] }


### PR DESCRIPTION
This PR updates the heapless crate to 0.8.0 and removes the version pin.