### PR TITLE
Update analyzer descriptors and request handling

### DIFF
--- a/cynthion/python/src/gateware/analyzer/top.py
+++ b/cynthion/python/src/gateware/analyzer/top.py
@@ -160,7 +160,7 @@ class USBAnalyzerApplet(Elaboratable):
             d.idVendor           = USB_VENDOR_ID
             d.idProduct          = USB_PRODUCT_ID
 
-            d.iManufacturer      = "LUNA"
+            d.iManufacturer      = "Cynthion Project"
             d.iProduct           = "USB Analyzer"
             d.iSerialNumber      = "[autodetect serial here]"
             d.bcdDevice          = 0.02

--- a/cynthion/python/src/gateware/analyzer/top.py
+++ b/cynthion/python/src/gateware/analyzer/top.py
@@ -16,22 +16,23 @@ import usb
 from datetime import datetime
 from enum import IntEnum, IntFlag
 
-from amaranth                          import Signal, Elaboratable, Module
-from amaranth.build.res                import ResourceError
-from usb_protocol.emitters             import DeviceDescriptorCollection
-from usb_protocol.types                import USBRequestType
+from amaranth                            import Signal, Elaboratable, Module
+from amaranth.build.res                  import ResourceError
+from usb_protocol.emitters               import DeviceDescriptorCollection
+from usb_protocol.types                  import USBRequestType
 
-from luna.usb2                         import USBDevice, USBStreamInEndpoint
-from luna                              import top_level_cli
+from luna.usb2                           import USBDevice, USBStreamInEndpoint
+from luna                                import top_level_cli
 
-from luna.gateware.usb.request.control import ControlRequestHandler
-from luna.gateware.usb.stream          import USBInStreamInterface
-from luna.gateware.stream.generator    import StreamSerializer
-from luna.gateware.utils.cdc           import synchronize
-from luna.gateware.architecture.car    import LunaECP5DomainGenerator
-from luna.gateware.interface.ulpi      import UTMITranslator
+from luna.gateware.usb.request.control   import ControlRequestHandler
+from luna.gateware.usb.stream            import USBInStreamInterface
+from luna.gateware.stream.generator      import StreamSerializer
+from luna.gateware.utils.cdc             import synchronize
+from luna.gateware.architecture.car      import LunaECP5DomainGenerator
+from luna.gateware.architecture.flash_sn import ECP5FlashUIDStringDescriptor
+from luna.gateware.interface.ulpi        import UTMITranslator
 
-from .analyzer                         import USBAnalyzer
+from .analyzer                           import USBAnalyzer
 
 import cynthion
 
@@ -162,7 +163,7 @@ class USBAnalyzerApplet(Elaboratable):
 
             d.iManufacturer      = "Cynthion Project"
             d.iProduct           = "USB Analyzer"
-            d.iSerialNumber      = "[autodetect serial here]"
+            d.iSerialNumber      = ECP5FlashUIDStringDescriptor
             d.bcdDevice          = 0.02
 
             d.bNumConfigurations = 1

--- a/cynthion/python/src/gateware/analyzer/top.py
+++ b/cynthion/python/src/gateware/analyzer/top.py
@@ -19,7 +19,7 @@ from enum import IntEnum, IntFlag
 from amaranth                            import Signal, Elaboratable, Module
 from amaranth.build.res                  import ResourceError
 from usb_protocol.emitters               import DeviceDescriptorCollection
-from usb_protocol.types                  import USBRequestType
+from usb_protocol.types                  import USBRequestType, USBRequestRecipient
 
 from luna.usb2                           import USBDevice, USBStreamInEndpoint
 from luna                                import top_level_cli
@@ -94,8 +94,11 @@ class USBAnalyzerVendorRequestHandler(ControlRequestHandler):
         m.submodules.transmitter = transmitter = \
             StreamSerializer(data_length=1, domain="usb", stream_type=USBInStreamInterface, max_length_width=1)
 
-        # Handle vendor requests
-        with m.If(setup.type == USBRequestType.VENDOR):
+        # Handle vendor requests to our interface.
+        with m.If(
+                (setup.type == USBRequestType.VENDOR) &
+                (setup.recipient == USBRequestRecipient.INTERFACE) &
+                (setup.index == 0)):
 
             m.d.comb += interface.claim.eq(
                 (setup.request == USBAnalyzerVendorRequests.GET_STATE) |

--- a/cynthion/python/src/gateware/analyzer/top.py
+++ b/cynthion/python/src/gateware/analyzer/top.py
@@ -175,6 +175,10 @@ class USBAnalyzerApplet(Elaboratable):
 
             with c.InterfaceDescriptor() as i:
                 i.bInterfaceNumber = 0
+                i.bInterfaceClass = 0xFF
+                i.bInterfaceSubclass = cynthion.shared.usb.bInterfaceSubClass.analyzer
+                i.bInterfaceProtocol = cynthion.shared.usb.bInterfaceProtocol.analyzer
+                i.iInterface = "USB Analyzer"
 
                 with i.EndpointDescriptor() as e:
                     e.bEndpointAddress = BULK_ENDPOINT_ADDRESS

--- a/cynthion/python/src/gateware/analyzer/top.py
+++ b/cynthion/python/src/gateware/analyzer/top.py
@@ -146,9 +146,10 @@ class USBAnalyzerApplet(Elaboratable):
         - DRAM backing for analysis
     """
 
-    def create_descriptors(self):
+    def create_descriptors(self, platform):
         """ Create the descriptors we want to use for our device. """
 
+        major, minor = platform.version
         descriptors = DeviceDescriptorCollection()
 
         #
@@ -164,7 +165,7 @@ class USBAnalyzerApplet(Elaboratable):
             d.iManufacturer      = "Cynthion Project"
             d.iProduct           = "USB Analyzer"
             d.iSerialNumber      = ECP5FlashUIDStringDescriptor
-            d.bcdDevice          = 0.02
+            d.bcdDevice          = major + (minor * 0.01)
 
             d.bNumConfigurations = 1
 
@@ -239,7 +240,7 @@ class USBAnalyzerApplet(Elaboratable):
         m.submodules.usb = usb = USBDevice(bus=uplink_ulpi)
 
         # Add our standard control endpoint to the device.
-        descriptors = self.create_descriptors()
+        descriptors = self.create_descriptors(platform)
         control_endpoint = usb.add_standard_control_endpoint(descriptors)
 
         # Add our vendor request handler to the control endpoint.

--- a/cynthion/python/src/gateware/platform/cynthion_r0_1.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_1.py
@@ -37,7 +37,7 @@ class CynthionPlatformRev0D1(CynthionPlatform):
     """ Board description for the pre-release r0.1 revision of Cynthion. """
 
     name        = "Cynthion r0.1"
-
+    version     = (0, 1)
     device      = "LFE5U-12F"
     package     = "BG256"
 

--- a/cynthion/python/src/gateware/platform/cynthion_r0_2.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_2.py
@@ -23,7 +23,7 @@ class CynthionPlatformRev0D2(CynthionPlatform):
     """ Board description for the pre-release r0.2 revision of Cynthion. """
 
     name        = "Cynthion r0.2"
-
+    version     = (0, 2)
     device      = "LFE5U-12F"
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")

--- a/cynthion/python/src/gateware/platform/cynthion_r0_3.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_3.py
@@ -23,7 +23,7 @@ class CynthionPlatformRev0D3(CynthionPlatform):
     """ Board description for the pre-release r0.3 revision of Cynthion. """
 
     name        = "Cynthion r0.3"
-
+    version     = (0, 3)
     device      = "LFE5U-12F"
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")

--- a/cynthion/python/src/gateware/platform/cynthion_r0_4.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_4.py
@@ -23,7 +23,7 @@ class CynthionPlatformRev0D4(CynthionPlatform):
     """ Board description for the pre-release r0.4 revision of Cynthion. """
 
     name        = "Cynthion r0.4"
-
+    version     = (0, 4)
     device      = "LFE5U-12F"
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")

--- a/cynthion/python/src/gateware/platform/cynthion_r0_5.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_5.py
@@ -23,7 +23,7 @@ class CynthionPlatformRev0D5(CynthionPlatform):
     """ Board description for the pre-release r0.5 revision of Cynthion. """
 
     name        = "Cynthion r0.5"
-
+    version     = (0, 5)
     device      = "LFE5U-12F"
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")

--- a/cynthion/python/src/gateware/platform/cynthion_r0_6.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_6.py
@@ -18,7 +18,7 @@ class CynthionPlatformRev0D6(CynthionPlatform):
     """ Board description for Cynthion r0.6 """
 
     name        = "Cynthion r0.6"
-
+    version     = (0, 6)
     device      = "LFE5U-12F"
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")

--- a/cynthion/python/src/gateware/platform/cynthion_r0_7.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_7.py
@@ -18,7 +18,7 @@ class CynthionPlatformRev0D7(CynthionPlatform):
     """ Board description for Cynthion r0.7 """
 
     name        = "Cynthion r0.7"
-
+    version     = (0, 7)
     device      = "LFE5U-25F"
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")

--- a/cynthion/python/src/gateware/platform/cynthion_r1_0.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_0.py
@@ -18,7 +18,7 @@ class CynthionPlatformRev1D0(CynthionPlatform):
     """ Board description for Cynthion r1.0 """
 
     name        = "Cynthion r1.0"
-
+    version     = (1, 0)
     device      = "LFE5U-12F"
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")

--- a/cynthion/python/src/gateware/platform/cynthion_r1_1.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_1.py
@@ -18,7 +18,7 @@ class CynthionPlatformRev1D1(CynthionPlatform):
     """ Board description for Cynthion r1.1 """
 
     name        = "Cynthion r1.1"
-
+    version     = (1, 1)
     device      = "LFE5U-12F"
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")

--- a/cynthion/python/src/gateware/platform/cynthion_r1_2.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_2.py
@@ -18,7 +18,7 @@ class CynthionPlatformRev1D2(CynthionPlatform):
     """ Board description for Cynthion r1.2 """
 
     name        = "Cynthion r1.2"
-
+    version     = (1, 2)
     device      = "LFE5U-12F"
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")

--- a/cynthion/python/src/gateware/platform/cynthion_r1_3.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_3.py
@@ -18,7 +18,7 @@ class CynthionPlatformRev1D3(CynthionPlatform):
     """ Board description for Cynthion r1.3 """
 
     name        = "Cynthion r1.3"
-
+    version     = (1, 3)
     device      = "LFE5U-12F"
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")

--- a/cynthion/python/src/gateware/platform/cynthion_r1_4.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_4.py
@@ -18,7 +18,7 @@ class CynthionPlatformRev1D4(CynthionPlatform):
     """ Board description for Cynthion r1.4 """
 
     name        = "Cynthion r1.4"
-
+    version     = (1, 4)
     device      = "LFE5U-12F"
     package     = "BG256"
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")


### PR DESCRIPTION
This PR updates the analyzer gateware's descriptors and request handling as per recent discussions.

The changes are as follows:

Device descriptor:
- Changed manufacturer string from `LUNA` to `Cynthion Project`.
- Set serial string from ECP5 configuration flash ID.
- Set bcdVersion to platform version rather than analyzer protocol version.

Interface descriptor:
- Set bInterfaceClass to 0xFF (vendor specific).
- Set bInterfaceSubclass and bInterfaceProtocol to values specified in `cynthion.shared`.

Request handler:
- Now accepts requests with the recipient as the interface, rather than the device.

Corresponding Packetry support is in https://github.com/greatscottgadgets/packetry/pull/93.