### PR TITLE
Analyzer descriptor fixes

### DIFF
--- a/cynthion/python/src/gateware/analyzer/top.py
+++ b/cynthion/python/src/gateware/analyzer/top.py
@@ -32,7 +32,7 @@ from luna.gateware.architecture.car      import LunaECP5DomainGenerator
 from luna.gateware.architecture.flash_sn import ECP5FlashUIDStringDescriptor
 from luna.gateware.interface.ulpi        import UTMITranslator
 
-from apollo_fpga.gateware.advertiser     import ApolloAdvertiser
+from apollo_fpga.gateware.advertiser     import ApolloAdvertiser, ApolloAdvertiserRequestHandler
 
 from .analyzer                           import USBAnalyzer
 
@@ -194,6 +194,7 @@ class USBAnalyzerApplet(Elaboratable):
                     i.bInterfaceNumber = 1
                     i.bInterfaceClass = 0xFF
                     i.bInterfaceSubclass = cynthion.shared.usb.bInterfaceSubClass.apollo
+                    i.bInterfaceProtocol = ApolloAdvertiserRequestHandler.PROTOCOL_VERSION
 
         return descriptors
 

--- a/cynthion/python/src/gateware/analyzer/top.py
+++ b/cynthion/python/src/gateware/analyzer/top.py
@@ -183,7 +183,6 @@ class USBAnalyzerApplet(Elaboratable):
                 i.bInterfaceClass = 0xFF
                 i.bInterfaceSubclass = cynthion.shared.usb.bInterfaceSubClass.analyzer
                 i.bInterfaceProtocol = cynthion.shared.usb.bInterfaceProtocol.analyzer
-                i.iInterface = "USB Analyzer"
 
                 with i.EndpointDescriptor() as e:
                     e.bEndpointAddress = BULK_ENDPOINT_ADDRESS


### PR DESCRIPTION
Remove interface string, which was causing some request handling bugs, and isn't currently needed for anything.

Set `bInterfaceProtocol` for Apollo stub.