### PR TITLE
repo: vendor in amaranth_boards.extensions and amaranth_boards.resources

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -99,7 +99,7 @@ Things can get somewhat hairy over time so I usually clean out my pyenv environm
 Then install the `cynthion` package with:
 
     cd cynthion.git/cynthion/python/
-    pip3 install --upgrade ".[gateware,gateware-soc]"
+    pip3 install --upgrade ".[gateware]"
 
 
 ## Build Packetry Gateware

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -2,5 +2,5 @@
 set -e
 python3.11 -m venv ci_env
 source ci_env/bin/activate
-pip install --upgrade cynthion/python/.[gateware,gateware-soc]
+pip install --upgrade cynthion/python/.[gateware]
 deactivate

--- a/cynthion/python/README.md
+++ b/cynthion/python/README.md
@@ -13,5 +13,5 @@ pip3 install --upgrade cynthion
 If you want to build any of the cynthion gateware designs you will need
 additional dependencies that can be installed with:
 ```
-pip3 install --upgrade cynthion[gateware,gateware-soc]
+pip3 install --upgrade cynthion[gateware]
 ```

--- a/cynthion/python/pyproject.toml
+++ b/cynthion/python/pyproject.toml
@@ -47,12 +47,8 @@ dependencies = [
 [project.optional-dependencies]
 gateware = [
     "amaranth==0.4.1",
-    "amaranth-boards @ git+https://github.com/amaranth-lang/amaranth-boards.git@main",
-    "amaranth-stdio @ git+https://github.com/amaranth-lang/amaranth-stdio@4a14bb17",
     "luna-usb @ git+https://github.com/greatscottgadgets/luna@main",
     #"luna-usb~=0.1"
-]
-gateware-soc = [
     "luna-soc @ git+https://github.com/greatscottgadgets/luna-soc@main",
     #"luna-soc~=0.1"
 ]

--- a/cynthion/python/src/__init__.py
+++ b/cynthion/python/src/__init__.py
@@ -1,6 +1,15 @@
 from __future__ import print_function
 # Alias objects to make them easier to import.
 
+# mildly evil hack to vendor in amaranth_stdio for the benefit of
+# apollo_fpga.gateware.advertiser.ApolloAdvertiser
+try:
+    import amaranth_stdio
+except:
+    import sys
+    from luna_soc.gateware.vendor import amaranth_stdio
+    sys.modules["amaranth_stdio"] = amaranth_stdio
+
 from .cynthion import Cynthion
 from .cynthion import CynthionSingleton
 from .cynthion import CynthionBoard

--- a/cynthion/python/src/gateware/platform/core.py
+++ b/cynthion/python/src/gateware/platform/core.py
@@ -13,7 +13,7 @@ try:
     from amaranth.vendor.lattice_ecp5 import LatticeECP5Platform
 except:
     from amaranth.vendor import LatticeECP5Platform
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from luna.gateware.platform.core import LUNAApolloPlatform
 from luna.gateware.architecture.car import LunaECP5DomainGenerator

--- a/cynthion/python/src/gateware/platform/cynthion_r0_2.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_2.py
@@ -7,7 +7,7 @@
 import os
 
 from amaranth.build import *
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from .core import CynthionPlatform
 

--- a/cynthion/python/src/gateware/platform/cynthion_r0_3.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_3.py
@@ -7,7 +7,7 @@
 import os
 
 from amaranth.build import *
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from .core import CynthionPlatform
 

--- a/cynthion/python/src/gateware/platform/cynthion_r0_4.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_4.py
@@ -7,7 +7,7 @@
 import os
 
 from amaranth.build import *
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from .core import CynthionPlatform
 

--- a/cynthion/python/src/gateware/platform/cynthion_r0_5.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_5.py
@@ -7,7 +7,7 @@
 import os
 
 from amaranth.build import *
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from .core import CynthionPlatform
 

--- a/cynthion/python/src/gateware/platform/cynthion_r0_6.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_6.py
@@ -7,7 +7,7 @@
 import os
 
 from amaranth.build import *
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from .core import CynthionPlatform
 

--- a/cynthion/python/src/gateware/platform/cynthion_r0_7.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_7.py
@@ -7,7 +7,7 @@
 import os
 
 from amaranth.build import *
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from .core import CynthionPlatform
 

--- a/cynthion/python/src/gateware/platform/cynthion_r1_0.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_0.py
@@ -7,7 +7,7 @@
 import os
 
 from amaranth.build import *
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from .core import CynthionPlatform
 

--- a/cynthion/python/src/gateware/platform/cynthion_r1_1.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_1.py
@@ -7,7 +7,7 @@
 import os
 
 from amaranth.build import *
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from .core import CynthionPlatform
 

--- a/cynthion/python/src/gateware/platform/cynthion_r1_2.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_2.py
@@ -7,7 +7,7 @@
 import os
 
 from amaranth.build import *
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from .core import CynthionPlatform
 

--- a/cynthion/python/src/gateware/platform/cynthion_r1_3.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_3.py
@@ -7,7 +7,7 @@
 import os
 
 from amaranth.build import *
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from .core import CynthionPlatform
 

--- a/cynthion/python/src/gateware/platform/cynthion_r1_4.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_4.py
@@ -7,7 +7,7 @@
 import os
 
 from amaranth.build import *
-from amaranth_boards.resources import *
+from ..vendor.amaranth_boards.resources import *
 
 from .core import CynthionPlatform
 

--- a/cynthion/python/src/gateware/soc/top.py
+++ b/cynthion/python/src/gateware/soc/top.py
@@ -11,10 +11,10 @@ import sys
 from amaranth                 import Cat, DomainRenamer, Elaboratable, Module, ResetSignal, Signal, Record
 from amaranth.build           import Attrs, Pins, PinsN, Resource, Subsignal
 from amaranth.hdl.rec         import Record
-from amaranth_stdio.serial    import AsyncSerial
 
 from luna_soc.gateware.vendor.lambdasoc.periph         import Peripheral
 from luna_soc.gateware.vendor.lambdasoc.periph.serial  import AsyncSerialPeripheral
+from luna_soc.gateware.vendor.amaranth_stdio.serial    import AsyncSerial
 
 from luna                            import configure_default_logging, top_level_cli
 from luna.gateware.platform          import NullPin

--- a/cynthion/python/src/gateware/vendor/README.md
+++ b/cynthion/python/src/gateware/vendor/README.md
@@ -1,0 +1,14 @@
+## Vendored Dependencies
+
+These are packages that have no official releases at this time and may also have implementation features that will be deprecated once official releases are made.
+
+The plan for these are to replace them as upstream development matures, official releases are made and we are able to migrate to them.
+
+The repositories and commit hashes for each of these are as follows:
+
+| Repository                                       | Commit                                                                        |
+| ------------------------------------------------ | ----------------------------------------------------------------------------- |
+| https://github.com/amaranth-lang/amaranth-boards | [`aba2300`](https://github.com/amaranth-lang/amaranth-boards/commit/aba2300)  |
+
+> __NOTE__
+> For `amaranth-boards` only the `extensions` and `resource` modules are vendored.

--- a/cynthion/python/src/gateware/vendor/amaranth_boards/__init__.py
+++ b/cynthion/python/src/gateware/vendor/amaranth_boards/__init__.py
@@ -1,0 +1,9 @@
+try:
+    from importlib import metadata as importlib_metadata
+    __version__ = importlib_metadata.version(__package__)
+    del importlib_metadata
+except ImportError:
+    # No importlib_metadata. This shouldn't normally happen, but some people prefer not installing
+    # packages via pip at all, instead using PYTHONPATH directly or copying the package files into
+    # `lib/pythonX.Y/site-packages`. Although not a recommended way, we still try to support it.
+    __version__ = "unknown" # :nocov:

--- a/cynthion/python/src/gateware/vendor/amaranth_boards/extensions/pmod.py
+++ b/cynthion/python/src/gateware/vendor/amaranth_boards/extensions/pmod.py
@@ -1,0 +1,94 @@
+# Reference: https://www.digilentinc.com/Pmods/Digilent-Pmod_%20Interface_Specification.pdf
+
+from amaranth.build import *
+
+
+__all__ = [
+    "PmodGPIOType1Resource",
+    "PmodSPIType2Resource",
+    "PmodSPIType2AResource",
+    "PmodUARTType3Resource",
+    "PmodUARTType4Resource",
+    "PmodUARTType4AResource",
+    "PmodHBridgeType5Resource",
+    "PmodDualHBridgeType6Resource",
+]
+
+
+def PmodGPIOType1Resource(name, number, *args, pmod):
+    return Resource(name, number,
+        Pins("1 2 3 4", dir="io", conn=("pmod", pmod)),
+        *args
+    )
+
+
+def PmodSPIType2Resource(name, number, *args, pmod):
+    return Resource(name, number,
+        Subsignal("cs",   PinsN("1", dir="o", conn=("pmod", pmod))),
+        Subsignal("clk",   Pins("2", dir="o", conn=("pmod", pmod))),
+        Subsignal("copi",  Pins("3", dir="o", conn=("pmod", pmod))),
+        Subsignal("cipo",  Pins("4", dir="i", conn=("pmod", pmod))),
+        *args
+    )
+
+
+def PmodSPIType2AResource(name, number, *args, pmod):
+    return Resource(name, number,
+        Subsignal("cs",   PinsN("1", dir="o", conn=("pmod", pmod))),
+        Subsignal("clk",   Pins("2", dir="o", conn=("pmod", pmod))),
+        Subsignal("copi",  Pins("3", dir="o", conn=("pmod", pmod))),
+        Subsignal("cipo",  Pins("4", dir="i", conn=("pmod", pmod))),
+        Subsignal("int",   Pins("7", dir="i", conn=("pmod", pmod))),
+        Subsignal("reset", Pins("8", dir="o", conn=("pmod", pmod))),
+        *args
+        )
+
+
+def PmodUARTType3Resource(name, number, *args, pmod):
+    return Resource(name, number,
+        Subsignal("cts",   Pins("1", dir="o", conn=("pmod", pmod))),
+        Subsignal("rts",   Pins("2", dir="i", conn=("pmod", pmod))),
+        Subsignal("rx",    Pins("3", dir="i", conn=("pmod", pmod))),
+        Subsignal("tx",    Pins("4", dir="o", conn=("pmod", pmod))),
+        *args
+    )
+
+
+def PmodUARTType4Resource(name, number, *args, pmod):
+    return Resource(name, number,
+        Subsignal("cts",   Pins("1", dir="i", conn=("pmod", pmod))),
+        Subsignal("tx",    Pins("2", dir="o", conn=("pmod", pmod))),
+        Subsignal("rx",    Pins("3", dir="i", conn=("pmod", pmod))),
+        Subsignal("rts",   Pins("4", dir="o", conn=("pmod", pmod))),
+        *args
+    )
+
+
+def PmodUARTType4AResource(name, number, *args, pmod):
+    return Resource(name, number,
+        Subsignal("cts",   Pins("1", dir="i", conn=("pmod", pmod))),
+        Subsignal("tx",    Pins("2", dir="o", conn=("pmod", pmod))),
+        Subsignal("rx",    Pins("3", dir="i", conn=("pmod", pmod))),
+        Subsignal("rts",   Pins("4", dir="o", conn=("pmod", pmod))),
+        Subsignal("int",   Pins("7", dir="i", conn=("pmod", pmod))),
+        Subsignal("reset", Pins("8", dir="o", conn=("pmod", pmod))),
+        *args
+    )
+
+
+def PmodHBridgeType5Resource(name, number, *args, pmod):
+    return Resource(name, number,
+        Subsignal("dir",   Pins("1", dir="o", conn=("pmod", pmod))),
+        Subsignal("en",    Pins("2", dir="o", conn=("pmod", pmod))),
+        Subsignal("sa",    Pins("3", dir="i", conn=("pmod", pmod))),
+        Subsignal("sb",    Pins("4", dir="i", conn=("pmod", pmod))),
+        *args
+    )
+
+
+def PmodDualHBridgeType6Resource(name, number, *args, pmod):
+    return Resource(name, number,
+        Subsignal("dir",   Pins("1 3", dir="o", conn=("pmod", pmod))),
+        Subsignal("en",    Pins("2 4", dir="o", conn=("pmod", pmod))),
+        *args
+    )

--- a/cynthion/python/src/gateware/vendor/amaranth_boards/resources/__init__.py
+++ b/cynthion/python/src/gateware/vendor/amaranth_boards/resources/__init__.py
@@ -1,0 +1,4 @@
+from .display import *
+from .interface import *
+from .memory import *
+from .user import *

--- a/cynthion/python/src/gateware/vendor/amaranth_boards/resources/display.py
+++ b/cynthion/python/src/gateware/vendor/amaranth_boards/resources/display.py
@@ -1,0 +1,36 @@
+from amaranth.build import *
+
+
+__all__ = ["Display7SegResource", "VGAResource"]
+
+
+def Display7SegResource(*args, a, b, c, d, e, f, g, dp=None, invert=False,
+                        conn=None, attrs=None):
+    ios = []
+    ios.append(Subsignal("a", Pins(a, dir="o", invert=invert, conn=conn, assert_width=1)))
+    ios.append(Subsignal("b", Pins(b, dir="o", invert=invert, conn=conn, assert_width=1)))
+    ios.append(Subsignal("c", Pins(c, dir="o", invert=invert, conn=conn, assert_width=1)))
+    ios.append(Subsignal("d", Pins(d, dir="o", invert=invert, conn=conn, assert_width=1)))
+    ios.append(Subsignal("e", Pins(e, dir="o", invert=invert, conn=conn, assert_width=1)))
+    ios.append(Subsignal("f", Pins(f, dir="o", invert=invert, conn=conn, assert_width=1)))
+    ios.append(Subsignal("g", Pins(g, dir="o", invert=invert, conn=conn, assert_width=1)))
+    if dp is not None:
+        ios.append(Subsignal("dp", Pins(dp, dir="o", invert=invert, conn=conn, assert_width=1)))
+    if attrs is not None:
+        ios.append(attrs)
+    return Resource.family(*args, default_name="display_7seg", ios=ios)
+
+
+def VGAResource(*args, r, g, b, vs, hs, invert_sync=False, conn=None, attrs=None):
+    ios = []
+
+    ios.append(Subsignal("r", Pins(r, dir="o", conn=conn)))
+    ios.append(Subsignal("g", Pins(g, dir="o", conn=conn)))
+    ios.append(Subsignal("b", Pins(b, dir="o", conn=conn)))
+    ios.append(Subsignal("hs", Pins(hs, dir="o", invert=invert_sync, conn=conn, assert_width=1)))
+    ios.append(Subsignal("vs", Pins(vs, dir="o", invert=invert_sync, conn=conn, assert_width=1)))
+
+    if attrs is not None:
+        ios.append(attrs)
+
+    return Resource.family(*args, default_name="vga", ios=ios)

--- a/cynthion/python/src/gateware/vendor/amaranth_boards/resources/interface.py
+++ b/cynthion/python/src/gateware/vendor/amaranth_boards/resources/interface.py
@@ -1,0 +1,144 @@
+from amaranth.build import *
+
+
+__all__ = [
+    "UARTResource", "IrDAResource", "SPIResource", "I2CResource",
+    "DirectUSBResource", "ULPIResource", "PS2Resource",
+]
+
+
+def UARTResource(*args, rx, tx, rts=None, cts=None, dtr=None, dsr=None, dcd=None, ri=None,
+                 conn=None, attrs=None, role=None):
+    if any(line is not None for line in (rts, cts, dtr, dsr, dcd, ri)):
+        assert role in ("dce", "dte")
+    if role == "dte":
+        dce_to_dte = "i"
+        dte_to_dce = "o"
+    else:
+        dce_to_dte = "o"
+        dte_to_dce = "i"
+
+    io = []
+    io.append(Subsignal("rx", Pins(rx, dir="i", conn=conn, assert_width=1)))
+    io.append(Subsignal("tx", Pins(tx, dir="o", conn=conn, assert_width=1)))
+    if rts is not None:
+        io.append(Subsignal("rts", Pins(rts, dir=dte_to_dce, conn=conn, assert_width=1)))
+    if cts is not None:
+        io.append(Subsignal("cts", Pins(cts, dir=dce_to_dte, conn=conn, assert_width=1)))
+    if dtr is not None:
+        io.append(Subsignal("dtr", Pins(dtr, dir=dte_to_dce, conn=conn, assert_width=1)))
+    if dsr is not None:
+        io.append(Subsignal("dsr", Pins(dsr, dir=dce_to_dte, conn=conn, assert_width=1)))
+    if dcd is not None:
+        io.append(Subsignal("dcd", Pins(dcd, dir=dce_to_dte, conn=conn, assert_width=1)))
+    if ri is not None:
+        io.append(Subsignal("ri", Pins(ri, dir=dce_to_dte, conn=conn, assert_width=1)))
+    if attrs is not None:
+        io.append(attrs)
+    return Resource.family(*args, default_name="uart", ios=io)
+
+
+def IrDAResource(number, *, rx, tx, en=None, sd=None,
+                 conn=None, attrs=None):
+    # Exactly one of en (active-high enable) or sd (shutdown, active-low enable) should
+    # be specified, and it is mapped to a logic level en subsignal.
+    assert (en is not None) ^ (sd is not None)
+
+    io = []
+    io.append(Subsignal("rx", Pins(rx, dir="i", conn=conn, assert_width=1)))
+    io.append(Subsignal("tx", Pins(tx, dir="o", conn=conn, assert_width=1)))
+    if en is not None:
+        io.append(Subsignal("en", Pins(en, dir="o", conn=conn, assert_width=1)))
+    if sd is not None:
+        io.append(Subsignal("en", PinsN(sd, dir="o", conn=conn, assert_width=1)))
+    if attrs is not None:
+        io.append(attrs)
+    return Resource("irda", number, *io)
+
+
+def SPIResource(*args, cs_n, clk, copi, cipo, int=None, reset=None,
+                conn=None, attrs=None, role="controller"):
+    assert role in ("controller", "peripheral")
+    assert copi is not None or cipo is not None # support unidirectional SPI
+
+    io = []
+    if role == "controller":
+        io.append(Subsignal("cs", PinsN(cs_n, dir="o", conn=conn)))
+        io.append(Subsignal("clk", Pins(clk, dir="o", conn=conn, assert_width=1)))
+        if copi is not None:
+            io.append(Subsignal("copi", Pins(copi, dir="o", conn=conn, assert_width=1)))
+        if cipo is not None:
+            io.append(Subsignal("cipo", Pins(cipo, dir="i", conn=conn, assert_width=1)))
+    else:  # peripheral
+        io.append(Subsignal("cs", PinsN(cs_n, dir="i", conn=conn, assert_width=1)))
+        io.append(Subsignal("clk", Pins(clk, dir="i", conn=conn, assert_width=1)))
+        if copi is not None:
+            io.append(Subsignal("copi", Pins(copi, dir="i", conn=conn, assert_width=1)))
+        if cipo is not None:
+            io.append(Subsignal("cipo", Pins(cipo, dir="oe", conn=conn, assert_width=1)))
+    if int is not None:
+        if role == "controller":
+            io.append(Subsignal("int", Pins(int, dir="i", conn=conn)))
+        else:
+            io.append(Subsignal("int", Pins(int, dir="oe", conn=conn, assert_width=1)))
+    if reset is not None:
+        if role == "controller":
+            io.append(Subsignal("reset", Pins(reset, dir="o", conn=conn)))
+        else:
+            io.append(Subsignal("reset", Pins(reset, dir="i", conn=conn, assert_width=1)))
+    if attrs is not None:
+        io.append(attrs)
+    return Resource.family(*args, default_name="spi", ios=io)
+
+
+def I2CResource(*args, scl, sda, conn=None, attrs=None):
+    io = []
+    io.append(Subsignal("scl", Pins(scl, dir="io", conn=conn, assert_width=1)))
+    io.append(Subsignal("sda", Pins(sda, dir="io", conn=conn, assert_width=1)))
+    if attrs is not None:
+        io.append(attrs)
+    return Resource.family(*args, default_name="i2c", ios=io)
+
+
+def DirectUSBResource(*args, d_p, d_n, pullup=None, vbus_valid=None, conn=None, attrs=None):
+
+    io = []
+    io.append(Subsignal("d_p", Pins(d_p, dir="io", conn=conn, assert_width=1)))
+    io.append(Subsignal("d_n", Pins(d_n, dir="io", conn=conn, assert_width=1)))
+    if pullup:
+        io.append(Subsignal("pullup", Pins(pullup, dir="o", conn=conn, assert_width=1)))
+    if vbus_valid:
+        io.append(Subsignal("vbus_valid", Pins(vbus_valid, dir="i", conn=conn, assert_width=1)))
+    if attrs is not None:
+        io.append(attrs)
+    return Resource.family(*args, default_name="usb", ios=io)
+
+
+def ULPIResource(*args, data, clk, dir, nxt, stp, rst=None,
+            clk_dir='i', rst_invert=False, attrs=None, conn=None):
+    assert clk_dir in ('i', 'o',)
+
+    io = []
+    io.append(Subsignal("data", Pins(data, dir="io", conn=conn, assert_width=8)))
+    io.append(Subsignal("clk", Pins(clk, dir=clk_dir, conn=conn, assert_width=1)))
+    io.append(Subsignal("dir", Pins(dir, dir="i", conn=conn, assert_width=1)))
+    io.append(Subsignal("nxt", Pins(nxt, dir="i", conn=conn, assert_width=1)))
+    io.append(Subsignal("stp", Pins(stp, dir="o", conn=conn, assert_width=1)))
+    if rst is not None:
+        io.append(Subsignal("rst", Pins(rst, dir="o", invert=rst_invert,
+            conn=conn, assert_width=1)))
+    if attrs is not None:
+        io.append(attrs)
+    return Resource.family(*args, default_name="usb", ios=io)
+
+
+def PS2Resource(*args, clk, dat, conn=None, attrs=None):
+    ios = []
+
+    ios.append(Subsignal("clk", Pins(clk, dir="i", conn=conn, assert_width=1))),
+    ios.append(Subsignal("dat", Pins(dat, dir="io", conn=conn, assert_width=1))),
+
+    if attrs is not None:
+        ios.append(attrs)
+
+    return Resource.family(*args, default_name="ps2", ios=ios)

--- a/cynthion/python/src/gateware/vendor/amaranth_boards/resources/memory.py
+++ b/cynthion/python/src/gateware/vendor/amaranth_boards/resources/memory.py
@@ -1,0 +1,190 @@
+from amaranth.build import *
+
+
+__all__ = [
+    "SPIFlashResources", "SDCardResources",
+    "SRAMResource", "SDRAMResource", "NORFlashResources",
+    "DDR3Resource",
+]
+
+
+def SPIFlashResources(*args, cs_n, clk, copi, cipo, wp_n=None, hold_n=None,
+                      conn=None, attrs=None):
+    resources = []
+
+    io_all = []
+    if attrs is not None:
+        io_all.append(attrs)
+    io_all.append(Subsignal("cs",  PinsN(cs_n, dir="o", conn=conn)))
+    io_all.append(Subsignal("clk", Pins(clk, dir="o", conn=conn, assert_width=1)))
+
+    io_1x = list(io_all)
+    io_1x.append(Subsignal("copi", Pins(copi, dir="o", conn=conn, assert_width=1)))
+    io_1x.append(Subsignal("cipo", Pins(cipo, dir="i", conn=conn, assert_width=1)))
+    if wp_n is not None and hold_n is not None:
+        io_1x.append(Subsignal("wp",   PinsN(wp_n,   dir="o", conn=conn, assert_width=1)))
+        io_1x.append(Subsignal("hold", PinsN(hold_n, dir="o", conn=conn, assert_width=1)))
+    resources.append(Resource.family(*args, default_name="spi_flash", ios=io_1x,
+                                     name_suffix="1x"))
+
+    io_2x = list(io_all)
+    io_2x.append(Subsignal("dq", Pins(" ".join([copi, cipo]), dir="io", conn=conn,
+                                      assert_width=2)))
+    resources.append(Resource.family(*args, default_name="spi_flash", ios=io_2x,
+                                     name_suffix="2x"))
+
+    if wp_n is not None and hold_n is not None:
+        io_4x = list(io_all)
+        io_4x.append(Subsignal("dq", Pins(" ".join([copi, cipo, wp_n, hold_n]), dir="io", conn=conn,
+                                          assert_width=4)))
+        resources.append(Resource.family(*args, default_name="spi_flash", ios=io_4x,
+                                         name_suffix="4x"))
+
+    return resources
+
+
+def SDCardResources(*args, clk, cmd, dat0, dat1=None, dat2=None, dat3=None, cd=None, wp_n=None,
+                    conn=None, attrs=None):
+    resources = []
+
+    io_common = []
+    if attrs is not None:
+        io_common.append(attrs)
+    if cd is not None:
+        io_common.append(Subsignal("cd", Pins(cd, dir="i", conn=conn, assert_width=1)))
+    if wp_n is not None:
+        io_common.append(Subsignal("wp", PinsN(wp_n, dir="i", conn=conn, assert_width=1)))
+
+    io_native = list(io_common)
+    io_native.append(Subsignal("clk", Pins(clk, dir="o", conn=conn, assert_width=1)))
+    io_native.append(Subsignal("cmd", Pins(cmd, dir="o", conn=conn, assert_width=1)))
+
+    io_1bit = list(io_native)
+    io_1bit.append(Subsignal("dat", Pins(dat0, dir="io", conn=conn, assert_width=1)))
+    if dat3 is not None:
+        # DAT3 has a pullup and works as electronic card detect
+        io_1bit.append(Subsignal("ecd", Pins(dat3, dir="i", conn=conn, assert_width=1)))
+    resources.append(Resource.family(*args, default_name="sd_card", ios=io_1bit,
+                                     name_suffix="1bit"))
+
+    if dat1 is not None and dat2 is not None and dat3 is not None:
+        io_4bit = list(io_native)
+        io_4bit.append(Subsignal("dat", Pins(" ".join((dat0, dat1, dat2, dat3)), dir="io",
+                                             conn=conn, assert_width=4)))
+        resources.append(Resource.family(*args, default_name="sd_card", ios=io_4bit,
+                                         name_suffix="4bit"))
+
+    if dat3 is not None:
+        io_spi = list(io_common)
+        # DAT3/CS# has a pullup and doubles as electronic card detect
+        io_spi.append(Subsignal("cs", PinsN(dat3, dir="io", conn=conn, assert_width=1)))
+        io_spi.append(Subsignal("clk", Pins(clk, dir="o", conn=conn, assert_width=1)))
+        io_spi.append(Subsignal("copi", Pins(cmd, dir="o", conn=conn, assert_width=1)))
+        io_spi.append(Subsignal("cipo", Pins(dat0, dir="i", conn=conn, assert_width=1)))
+        resources.append(Resource.family(*args, default_name="sd_card", ios=io_spi,
+                                         name_suffix="spi"))
+
+    return resources
+
+
+def SRAMResource(*args, cs_n, oe_n=None, we_n, a, d, dm_n=None,
+                 conn=None, attrs=None):
+    io = []
+    io.append(Subsignal("cs", PinsN(cs_n, dir="o", conn=conn, assert_width=1)))
+    if oe_n is not None:
+        # Asserted WE# deactivates the D output buffers, so WE# can be used to replace OE#.
+        io.append(Subsignal("oe", PinsN(oe_n, dir="o", conn=conn, assert_width=1)))
+    io.append(Subsignal("we", PinsN(we_n, dir="o", conn=conn, assert_width=1)))
+    io.append(Subsignal("a", Pins(a, dir="o", conn=conn)))
+    io.append(Subsignal("d", Pins(d, dir="io", conn=conn)))
+    if dm_n is not None:
+        io.append(Subsignal("dm", PinsN(dm_n, dir="o", conn=conn))) # dm="LB# UB#"
+    if attrs is not None:
+        io.append(attrs)
+    return Resource.family(*args, default_name="sram", ios=io)
+
+
+def SDRAMResource(*args, clk, cke=None, cs_n=None, we_n, ras_n, cas_n, ba, a, dq, dqm=None,
+                  conn=None, attrs=None):
+    io = []
+    io.append(Subsignal("clk", Pins(clk, dir="o", conn=conn, assert_width=1)))
+    if cke is not None:
+        io.append(Subsignal("clk_en", Pins(cke, dir="o", conn=conn, assert_width=1)))
+    if cs_n is not None:
+        io.append(Subsignal("cs", PinsN(cs_n,  dir="o", conn=conn, assert_width=1)))
+    io.append(Subsignal("we",  PinsN(we_n,  dir="o", conn=conn, assert_width=1)))
+    io.append(Subsignal("ras", PinsN(ras_n, dir="o", conn=conn, assert_width=1)))
+    io.append(Subsignal("cas", PinsN(cas_n, dir="o", conn=conn, assert_width=1)))
+    io.append(Subsignal("ba", Pins(ba, dir="o", conn=conn)))
+    io.append(Subsignal("a",  Pins(a,  dir="o", conn=conn)))
+    io.append(Subsignal("dq", Pins(dq, dir="io", conn=conn)))
+    if dqm is not None:
+        io.append(Subsignal("dqm", Pins(dqm, dir="o", conn=conn))) # dqm="LDQM# UDQM#"
+    if attrs is not None:
+        io.append(attrs)
+    return Resource.family(*args, default_name="sdram", ios=io)
+
+
+def NORFlashResources(*args, rst=None, byte_n=None, cs_n, oe_n, we_n, wp_n, by, a, dq,
+                      conn=None, attrs=None):
+    resources = []
+
+    io_common = []
+    if rst is not None:
+        io_common.append(Subsignal("rst", Pins(rst, dir="o", conn=conn, assert_width=1)))
+    io_common.append(Subsignal("cs", PinsN(cs_n, dir="o", conn=conn, assert_width=1)))
+    io_common.append(Subsignal("oe", PinsN(oe_n, dir="o", conn=conn, assert_width=1)))
+    io_common.append(Subsignal("we", PinsN(we_n, dir="o", conn=conn, assert_width=1)))
+    io_common.append(Subsignal("wp", PinsN(wp_n, dir="o", conn=conn, assert_width=1)))
+    io_common.append(Subsignal("rdy", Pins(by, dir="i", conn=conn, assert_width=1)))
+
+    if byte_n is None:
+        io_8bit = list(io_common)
+        io_8bit.append(Subsignal("a", Pins(a, dir="o", conn=conn)))
+        io_8bit.append(Subsignal("dq", Pins(dq, dir="io", conn=conn, assert_width=8)))
+        resources.append(Resource.family(*args, default_name="nor_flash", ios=io_8bit,
+                                         name_suffix="8bit"))
+    else:
+        *dq_0_14, dq15_am1 = dq.split()
+
+        # If present in a requested resource, this pin needs to be strapped correctly.
+        io_common.append(Subsignal("byte", PinsN(byte_n, dir="o", conn=conn, assert_width=1)))
+
+        io_8bit = list(io_common)
+        io_8bit.append(Subsignal("a", Pins(" ".join((dq15_am1, a)), dir="o", conn=conn)))
+        io_8bit.append(Subsignal("dq", Pins(" ".join(dq_0_14[:8]), dir="io", conn=conn,
+                                            assert_width=8)))
+        resources.append(Resource.family(*args, default_name="nor_flash", ios=io_8bit,
+                                         name_suffix="8bit"))
+
+        io_16bit = list(io_common)
+        io_16bit.append(Subsignal("a", Pins(a, dir="o", conn=conn)))
+        io_16bit.append(Subsignal("dq", Pins(dq, dir="io", conn=conn, assert_width=16)))
+        resources.append(Resource.family(*args, default_name="nor_flash", ios=io_16bit,
+                                         name_suffix="16bit"))
+
+    return resources
+
+
+def DDR3Resource(*args, rst_n=None, clk_p, clk_n, clk_en, cs_n, we_n, ras_n, cas_n, a, ba, dqs_p, dqs_n, dq, dm, odt,
+                 conn=None, diff_attrs=None, attrs=None):
+    ios = []
+
+    ios.append(Subsignal("rst", PinsN(rst_n, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("clk", DiffPairs(clk_p, clk_n, dir="o", conn=conn, assert_width=1), diff_attrs))
+    ios.append(Subsignal("clk_en", Pins(clk_en, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("cs", PinsN(cs_n, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("we", PinsN(we_n, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("ras", PinsN(ras_n, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("cas", PinsN(cas_n, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("a", Pins(a, dir="o", conn=conn)))
+    ios.append(Subsignal("ba", Pins(ba, dir="o", conn=conn)))
+    ios.append(Subsignal("dqs", DiffPairs(dqs_p, dqs_n, dir="io", conn=conn), diff_attrs))
+    ios.append(Subsignal("dq", Pins(dq, dir="io", conn=conn)))
+    ios.append(Subsignal("dm", Pins(dm, dir="o", conn=conn)))
+    ios.append(Subsignal("odt", Pins(odt, dir="o", conn=conn, assert_width=1)))
+
+    if attrs is not None:
+        ios.append(attrs)
+
+    return Resource.family(*args, default_name="ddr3", ios=ios)

--- a/cynthion/python/src/gateware/vendor/amaranth_boards/resources/user.py
+++ b/cynthion/python/src/gateware/vendor/amaranth_boards/resources/user.py
@@ -1,0 +1,43 @@
+from amaranth.build import *
+
+
+__all__ = ["LEDResources", "RGBLEDResource", "ButtonResources", "SwitchResources"]
+
+
+def _SplitResources(*args, pins, invert=False, conn=None, attrs=None, default_name, dir):
+    assert isinstance(pins, (str, list, dict))
+
+    if isinstance(pins, str):
+        pins = pins.split()
+    if isinstance(pins, list):
+        pins = dict(enumerate(pins))
+
+    resources = []
+    for number, pin in pins.items():
+        ios = [Pins(pin, dir=dir, invert=invert, conn=conn)]
+        if attrs is not None:
+            ios.append(attrs)
+        resources.append(Resource.family(*args, number, default_name=default_name, ios=ios))
+    return resources
+
+
+def LEDResources(*args, **kwargs):
+    return _SplitResources(*args, **kwargs, default_name="led", dir="o")
+
+
+def RGBLEDResource(*args, r, g, b, invert=False, conn=None, attrs=None):
+    ios = []
+    ios.append(Subsignal("r", Pins(r, dir="o", invert=invert, conn=conn, assert_width=1)))
+    ios.append(Subsignal("g", Pins(g, dir="o", invert=invert, conn=conn, assert_width=1)))
+    ios.append(Subsignal("b", Pins(b, dir="o", invert=invert, conn=conn, assert_width=1)))
+    if attrs is not None:
+        ios.append(attrs)
+    return Resource.family(*args, default_name="rgb_led", ios=ios)
+
+
+def ButtonResources(*args, **kwargs):
+    return _SplitResources(*args, **kwargs, default_name="button", dir="i")
+
+
+def SwitchResources(*args, **kwargs):
+    return _SplitResources(*args, **kwargs, default_name="switch", dir="i")


### PR DESCRIPTION
This is the companion PR to: https://github.com/greatscottgadgets/luna-soc/pull/28 (already merged)

What these two PR's do is to temporarily vendor specific commits of `amaranth-boards`, `amaranth-stdio` and `amaranth-soc` as they have no official pypi releases and are in heavy flux at this time.

| Repository                                       | Commit                                                                        |
| ------------------------------------------------ | ----------------------------------------------------------------------------- |
| https://github.com/amaranth-lang/amaranth-boards | [`aba2300`](https://github.com/amaranth-lang/amaranth-boards/commit/aba2300)  |
| https://github.com/amaranth-lang/amaranth-soc   | [`d2185e3`](https://github.com/amaranth-lang/amaranth-soc/commit/d2185e3)     |
| https://github.com/amaranth-lang/amaranth-stdio | [`4a14bb17`](https://github.com/amaranth-lang/amaranth-stdio/commit/4a14bb17) |
