### PR TITLE
Add self-test device on AUX port to analyzer gateware

### DIFF
--- a/shared/usb.toml
+++ b/shared/usb.toml
@@ -25,6 +25,7 @@ example_2       = 0x0002 # pid.codes Test PID 2
 example_3       = 0x0003 # pid.codes Test PID 3
 example_4       = 0x0004 # pid.codes Test PID 4
 example_5       = 0x0005 # pid.codes Test PID 5
+analyzer_test   = 0x000a # pid.codes Test PID 10
 
 # iManufacturer
 #


### PR DESCRIPTION
This PR adds a self-test device to the analyzer gateware, which appears on the AUX port.

By default, the self-test device is enabled and will enumerate at high speed. It can be disconnected, and reconnected at other speeds, via control requests to the analyzer.

The device provides a single interrupt IN endpoint, which outputs bytes from a counter.

This feature supports hardware-in-the-loop testing of the analyzer gateware and host capture software.