### PR TITLE
gateware.platform: update default USB PHY to aux/host

### DIFF
--- a/cynthion/python/src/gateware/platform/cynthion_r0_1.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_1.py
@@ -49,7 +49,7 @@ class CynthionPlatformRev0D1(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our target PHY.
-    default_usb_connection = "target_phy"
+    default_usb_connection = "host_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.

--- a/cynthion/python/src/gateware/platform/cynthion_r0_2.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_2.py
@@ -29,7 +29,7 @@ class CynthionPlatformRev0D2(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our target PHY.
-    default_usb_connection = "target_phy"
+    default_usb_connection = "host_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.

--- a/cynthion/python/src/gateware/platform/cynthion_r0_3.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_3.py
@@ -29,7 +29,7 @@ class CynthionPlatformRev0D3(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our target PHY.
-    default_usb_connection = "target_phy"
+    default_usb_connection = "host_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.

--- a/cynthion/python/src/gateware/platform/cynthion_r0_4.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_4.py
@@ -29,7 +29,7 @@ class CynthionPlatformRev0D4(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our target PHY.
-    default_usb_connection = "target_phy"
+    default_usb_connection = "host_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.

--- a/cynthion/python/src/gateware/platform/cynthion_r0_5.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_5.py
@@ -29,7 +29,7 @@ class CynthionPlatformRev0D5(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our target PHY.
-    default_usb_connection = "target_phy"
+    default_usb_connection = "host_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.

--- a/cynthion/python/src/gateware/platform/cynthion_r0_6.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_6.py
@@ -23,7 +23,7 @@ class CynthionPlatformRev0D6(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our control PHY.
-    default_usb_connection = "control_phy"
+    default_usb_connection = "aux_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.

--- a/cynthion/python/src/gateware/platform/cynthion_r0_7.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r0_7.py
@@ -23,7 +23,7 @@ class CynthionPlatformRev0D7(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our control PHY.
-    default_usb_connection = "control_phy"
+    default_usb_connection = "aux_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.

--- a/cynthion/python/src/gateware/platform/cynthion_r1_0.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_0.py
@@ -23,7 +23,7 @@ class CynthionPlatformRev1D0(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our control PHY.
-    default_usb_connection = "control_phy"
+    default_usb_connection = "aux_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.

--- a/cynthion/python/src/gateware/platform/cynthion_r1_1.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_1.py
@@ -23,7 +23,7 @@ class CynthionPlatformRev1D1(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our control PHY.
-    default_usb_connection = "control_phy"
+    default_usb_connection = "aux_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.

--- a/cynthion/python/src/gateware/platform/cynthion_r1_2.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_2.py
@@ -23,7 +23,7 @@ class CynthionPlatformRev1D2(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our control PHY.
-    default_usb_connection = "control_phy"
+    default_usb_connection = "aux_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.

--- a/cynthion/python/src/gateware/platform/cynthion_r1_3.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_3.py
@@ -23,7 +23,7 @@ class CynthionPlatformRev1D3(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our control PHY.
-    default_usb_connection = "control_phy"
+    default_usb_connection = "aux_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.

--- a/cynthion/python/src/gateware/platform/cynthion_r1_4.py
+++ b/cynthion/python/src/gateware/platform/cynthion_r1_4.py
@@ -23,7 +23,7 @@ class CynthionPlatformRev1D4(CynthionPlatform):
     speed       = os.getenv("ECP5_SPEED_GRADE", "8")
 
     # By default, assume we'll be connecting via our control PHY.
-    default_usb_connection = "control_phy"
+    default_usb_connection = "aux_phy"
 
     #
     # Preferred DRAM bus I/O (de)-skewing constants.


### PR DESCRIPTION
Now that port sharing is not setup automagically, using the control port PHY by default is not ideal as it needs extra setup to work. This change switches the default to aux as it's just a standard device port, and also changes older revisions to use their host PHY to match.