### PR TITLE
Add timestamping to analyzer

### DIFF
--- a/shared/usb.toml
+++ b/shared/usb.toml
@@ -81,5 +81,5 @@ moondancer = 0x20
 #   0xff = unused
 #
 [bInterfaceProtocol]
-analyzer   = 0x00
+analyzer   = 0x01
 moondancer = 0x00


### PR DESCRIPTION
This PR adds timestamping to the analyzer stream, along with the basic mechanism for non-packet events, used to support timestamp rollovers.

- Bumps protocol version to `0x01`.
- Should be merged together with:
https://github.com/greatscottgadgets/packetry/pull/108
- The two PRs can be tested together via:
https://github.com/greatscottgadgets/cynthion-analyzer/pull/7.

Analyzer unit tests have been updated to test the new features.

Closes #50.