### PR TITLE
python: update apollo_fpga dependency to released version

### DIFF
--- a/cynthion/python/pyproject.toml
+++ b/cynthion/python/pyproject.toml
@@ -41,8 +41,7 @@ dependencies = [
     "tomli",
     "tqdm",
     "pygreat~=2024.0",
-    "apollo_fpga @ git+https://github.com/greatscottgadgets/apollo.git",  # temporarily pull from git until apollo release
-    #"apollo~=???",
+    "apollo_fpga~=1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This is the final outstanding dependency before we can start publishing the `cynthion` package to PyPI! 🎉