### PR TITLE
firmware: update moondancer product string to 'Facedancer'

### DIFF
--- a/cynthion/rust/src/shared.rs
+++ b/cynthion/rust/src/shared.rs
@@ -58,7 +58,8 @@ pub mod usb {
         use super::TOML;
         pub static apollo: &str = TOML.b_manufacturer_string.apollo;
         pub static bulk_speed_test: &str = TOML.b_manufacturer_string.bulk_speed_test;
-        pub static cynthion: &str = TOML.b_manufacturer_string.cynthion;
+        pub static analyzer: &str = TOML.b_manufacturer_string.analyzer;
+        pub static moondancer: &str = TOML.b_manufacturer_string.moondancer;
         pub static example: &str = TOML.b_manufacturer_string.example;
     }
 
@@ -66,7 +67,8 @@ pub mod usb {
         use super::TOML;
         pub static apollo: &str = TOML.b_product_string.apollo;
         pub static bulk_speed_test: &str = TOML.b_product_string.bulk_speed_test;
-        pub static cynthion: &str = TOML.b_product_string.cynthion;
+        pub static analyzer: &str = TOML.b_product_string.analyzer;
+        pub static moondancer: &str = TOML.b_product_string.moondancer;
         pub static example: &str = TOML.b_product_string.example;
         pub static example_2: &str = TOML.b_product_string.example_2;
         pub static example_3: &str = TOML.b_product_string.example_3;

--- a/firmware/moondancer/examples/bulk_speed_test.rs
+++ b/firmware/moondancer/examples/bulk_speed_test.rs
@@ -609,7 +609,7 @@ static USB_STRING_DESCRIPTOR_1: StringDescriptor =
 static USB_STRING_DESCRIPTOR_2: StringDescriptor =
     StringDescriptor::new(cynthion::shared::usb::bProductString::bulk_speed_test);
 static USB_STRING_DESCRIPTOR_3: StringDescriptor =
-    StringDescriptor::new(moondancer::usb::DEVICE_SERIAL_STRING);
+    StringDescriptor::new("0000000000000000");
 
 static USB_STRING_DESCRIPTORS: &[&StringDescriptor] = &[
     &USB_STRING_DESCRIPTOR_1,

--- a/firmware/moondancer/examples/usb_hal.rs
+++ b/firmware/moondancer/examples/usb_hal.rs
@@ -487,7 +487,7 @@ static USB_STRING_DESCRIPTOR_1: StringDescriptor =
 static USB_STRING_DESCRIPTOR_2: StringDescriptor =
     StringDescriptor::new(cynthion::shared::usb::bProductString::example);
 static USB_STRING_DESCRIPTOR_3: StringDescriptor =
-    StringDescriptor::new(moondancer::usb::DEVICE_SERIAL_STRING);
+    StringDescriptor::new("0000000000000000");
 pub static USB_STRING_DESCRIPTOR_4: StringDescriptor = StringDescriptor::new("config 1");
 pub static USB_STRING_DESCRIPTOR_5: StringDescriptor = StringDescriptor::new("interface 0");
 pub static USB_STRING_DESCRIPTOR_6: StringDescriptor = StringDescriptor::new("other config 1");

--- a/firmware/moondancer/src/bin/moondancer.rs
+++ b/firmware/moondancer/src/bin/moondancer.rs
@@ -128,11 +128,10 @@ impl<'a> Firmware<'a> {
         moondancer::log::set_port(moondancer::log::Port::Both);
         moondancer::log::init();
         info!(
-            "{} {} r{}.{}",
-            cynthion::shared::usb::bManufacturerString::cynthion,
-            cynthion::shared::usb::bProductString::cynthion,
-            board_major,
-            board_minor,
+            "{} {} v{}",
+            env!("CARGO_PKG_AUTHORS"),
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
         );
         info!("Logging initialized");
 
@@ -149,7 +148,7 @@ impl<'a> Firmware<'a> {
         #[allow(clippy::items_after_statements)]
         let string_descriptors = {
             static mut UUID: heapless::String<16> = heapless::String::new();
-            static mut ISERIALNUMBER: StringDescriptor = StringDescriptor::new("UNKNOWN ");
+            static mut ISERIALNUMBER: StringDescriptor = StringDescriptor::new("0000000000000000");
             unsafe {
                 UUID = uuid.clone();
                 ISERIALNUMBER = StringDescriptor::new(UUID.as_str());

--- a/firmware/moondancer/src/usb.rs
+++ b/firmware/moondancer/src/usb.rs
@@ -6,10 +6,6 @@ use smolusb::descriptor::{
     LanguageId, StringDescriptor, StringDescriptorZero,
 };
 
-// - constants ----------------------------------------------------------------
-
-pub const DEVICE_SERIAL_STRING: &str = "moondancer"; // TODO read flash uid
-
 // - vendor request -----------------------------------------------------------
 
 pub mod vendor {
@@ -209,12 +205,12 @@ pub static STRING_DESCRIPTOR_0: StringDescriptorZero =
 
 // manufacturer
 pub static STRING_DESCRIPTOR_1: StringDescriptor =
-    StringDescriptor::new(cynthion::shared::usb::bManufacturerString::cynthion);
+    StringDescriptor::new(cynthion::shared::usb::bManufacturerString::moondancer);
 // product
 pub static STRING_DESCRIPTOR_2: StringDescriptor =
-    StringDescriptor::new(cynthion::shared::usb::bProductString::cynthion);
+    StringDescriptor::new(cynthion::shared::usb::bProductString::moondancer);
 // serial
-pub static STRING_DESCRIPTOR_3: StringDescriptor = StringDescriptor::new(DEVICE_SERIAL_STRING);
+pub static STRING_DESCRIPTOR_3: StringDescriptor = StringDescriptor::new("0000000000000000");
 
 // configuration #0
 pub static STRING_DESCRIPTOR_4: StringDescriptor = StringDescriptor::new("config0");

--- a/shared/usb.toml
+++ b/shared/usb.toml
@@ -33,8 +33,9 @@ analyzer_test   = 0x000a # pid.codes Test PID 10
 #
 [bManufacturerString]
 apollo          = "Great Scott Gadgets"
-bulk_speed_test = "LUNA"
-cynthion        = "Great Scott Gadgets"
+bulk_speed_test = "Luna Project"
+analyzer        = "Cynthion Project"
+moondancer      = "Cynthion Project"
 example         = "https://pid.codes/1209/"
 
 # iProduct
@@ -42,9 +43,10 @@ example         = "https://pid.codes/1209/"
 # USB Device Descriptor product string field value.
 #
 [bProductString]
-apollo          = "Apollo Debugger"
-bulk_speed_test = "IN speed test"
-cynthion        = "Cynthion USB Test Instrument"
+apollo          = "Cynthion Apollo Debugger"
+bulk_speed_test = "Bulk Speed Test"
+analyzer        = "USB Analyzer"
+moondancer      = "Facedancer"
 example         = "pid.codes Test PID 1"
 example_2       = "pid.codes Test PID 2"
 example_3       = "pid.codes Test PID 3"


### PR DESCRIPTION
For consistency with USB analyzer:

* `bProductString: "Facedancer"`
* `bManufacturerString: "Cynthion Project"`