### PR TITLE
Close existing Apollo device before running selftest

### DIFF
--- a/cynthion/python/src/commands/cynthion_run.py
+++ b/cynthion/python/src/commands/cynthion_run.py
@@ -37,6 +37,8 @@ def _run_selftest(device, args):
     from cynthion.selftest.host import StandaloneTester
 
     run_bitstream(device, find_cynthion_bitstream(device, f"selftest.bit"))
+    device.close()
+
     selftest_device = SelftestDevice()
 
     tester = StandaloneTester(selftest_device)


### PR DESCRIPTION
Fixes a permission error on Windows, due to opening a second handle to the same USB device.

Tested on Windows 10.