### PR TITLE
packaging: install cynthion assets in cynthion package directory

### DIFF
--- a/cynthion/python/pyproject.toml
+++ b/cynthion/python/pyproject.toml
@@ -59,12 +59,12 @@ Issues        = "https://github.com/greatscottgadgets/cynthion/issues"
 include-package-data = true
 
 [tool.setuptools.package-dir]
-cynthion = "src"
-assets   = "assets"
+"cynthion"        = "src"
+"cynthion.assets" = "assets"
 
 [tool.setuptools.package-data]
 "cynthion.shared" = ["*.toml"]
-"assets" = ["*.rules", "*.bin", "**/*.bit"]
+"cynthion.assets" = ["*.rules", "*.bin", "**/*.bit"]
 
 [tool.setuptools-git-versioning]
 enabled = true

--- a/cynthion/python/src/commands/util.py
+++ b/cynthion/python/src/commands/util.py
@@ -55,10 +55,27 @@ def get_bitstream_information():
     }
 
 
+def _find_assets_path():
+    try:
+        # <= 3.8
+        from importlib_resources import files
+    except:
+        # >= 3.9
+        from importlib.resources import files
+
+    pkg_path = files("cynthion")
+    if os.path.basename(pkg_path) == "src":
+        assets = os.path.join(pkg_path, "../assets")
+    else:
+        assets = os.path.join(pkg_path, "assets")
+
+    return os.path.normpath(os.path.join(pkg_path, assets))
+
+
 def find_cynthion_asset(filename):
     """Returns the path to the requested asset filename"""
-    module_path = os.path.dirname(__file__)
-    asset_path = os.path.join(module_path, '../../assets', filename)
+
+    asset_path = os.path.join(_find_assets_path(), filename)
     if os.path.isfile(asset_path):
         return asset_path
     else:
@@ -70,8 +87,7 @@ def find_cynthion_bitstream(device, filename):
 
     platform = _get_appropriate_platform_name(device)
 
-    module_path = os.path.dirname(__file__)
-    bitstream_path = os.path.join(module_path, '../../assets/', platform, filename)
+    bitstream_path = os.path.join(_find_assets_path(), platform, filename)
     if os.path.isfile(bitstream_path):
         return bitstream_path
     else:


### PR DESCRIPTION
I'm really not sure why this was working at all for anyone that wasn't running the package from source, but this PR solves two problems:

1. The `cynthion` Python package was installing the assets directory in `site-packages/assets` instead of `site-packages/cynthion/assets`.
2. The relative path needs to be set correctly depending on whether it was installed from wheel or an editable install in the source directory.

closes #126