### PR TITLE
gateware.analyzer.HyperRAMPacketFIFO: fix consumer blocking FIFO writes

### DIFF
--- a/cynthion/python/src/gateware/analyzer/fifo.py
+++ b/cynthion/python/src/gateware/analyzer/fifo.py
@@ -100,8 +100,8 @@ class HyperRAMPacketFIFO(Elaboratable):
             # WRITE: Finish when there's no space or incoming data.
             m.d.comb += psram.final_word.eq((word_count == (depth-1)) | self.input.last)
         with m.Else():
-            # READ: Finish when PSRAM is empty or the consumer stalls the output stream.
-            m.d.comb += psram.final_word.eq((word_count == 1) | ~self.output.ready)
+            # READ: Finish when PSRAM is empty or the output FIFO is full.
+            m.d.comb += psram.final_word.eq((word_count == 1) | (out_fifo.level == out_fifo.depth - 1))
 
         #
         # HyperRAM Packet FIFO state machine

--- a/cynthion/python/src/gateware/analyzer/top.py
+++ b/cynthion/python/src/gateware/analyzer/top.py
@@ -331,7 +331,7 @@ class USBAnalyzerApplet(Elaboratable):
         # Follow this with a HyperRAM FIFO for additional buffering.
         reset_on_start = ResetInserter(analyzer.discarding)
         m.submodules.psram_fifo = psram_fifo = reset_on_start(
-            HyperRAMPacketFIFO(out_fifo_depth=4096))
+            HyperRAMPacketFIFO(out_fifo_depth=128))
 
         # Convert the 16-bit stream into an 8-bit one for output.
         m.submodules.s16to8 = s16to8 = reset_on_start(Stream16to8())


### PR DESCRIPTION
Fix the stop condition for final word during read bursts.