### PR TITLE
Improve USBProxy reliability

### DIFF
--- a/cynthion/rust/Cargo.toml
+++ b/cynthion/rust/Cargo.toml
@@ -12,5 +12,8 @@ documentation = "https://cynthion.readthedocs.io"
 edition = "2021"
 rust-version = "1.68"
 
+[features]
+nightly = []
+
 [dependencies]
 static-toml = { version = "1.0.1" }

--- a/firmware/ladybug/Cargo.toml
+++ b/firmware/ladybug/Cargo.toml
@@ -18,5 +18,6 @@ bench = false
 [features]
 disable = []
 enable = []
+nightly = []
 
 [dependencies]

--- a/firmware/moondancer/.cargo/cynthion.sh
+++ b/firmware/moondancer/.cargo/cynthion.sh
@@ -13,12 +13,12 @@ echo "Using uart: UART=$UART"
 if [ ! -f $BITSTREAM ]
 then
     echo
-    echo "Failed to locate the Cynthion SoC bitstream file."
+    echo "Failed to locate the SoC bitstream file."
     echo
     echo "The SoC bitstream file can be generated with:"
     echo
     echo "    cd ../../cynthion/python/"
-    echo "    make soc"
+    echo "    make facedancer"
     echo
     exit 1
 fi

--- a/firmware/moondancer/Cargo.toml
+++ b/firmware/moondancer/Cargo.toml
@@ -51,6 +51,8 @@ nightly = [
     "lunasoc-hal/nightly",
 ]
 
+alloc = []
+
 
 # - dependencies --------------------------------------------------------------
 

--- a/firmware/moondancer/src/debug.rs
+++ b/firmware/moondancer/src/debug.rs
@@ -88,6 +88,7 @@ mod ladybug_impl {
                         w.odr().bits(self.b.load(Ordering::Relaxed))
                     });
                 }
+                _ => {}
             }
         }
 
@@ -105,6 +106,7 @@ mod ladybug_impl {
                         w.odr().bits(self.b.load(Ordering::Relaxed))
                     });
                 }
+                _ => {}
             }
         }
     }

--- a/firmware/smolusb/src/control.rs
+++ b/firmware/smolusb/src/control.rs
@@ -221,7 +221,9 @@ where
                         match (&recipient, &feature) {
                             (Recipient::Endpoint, Feature::EndpointHalt) => {
                                 let endpoint_address = (setup_packet.index & 0xff) as u8;
-                                usb.clear_feature_endpoint_halt(endpoint_address);
+                                let endpoint_number = endpoint_address & 0x7f;
+                                let direction = Direction::from(endpoint_address);
+                                usb.clear_feature_endpoint_halt(endpoint_number, direction);
                                 self.next = State::Complete;
                                 self.write_zlp(usb);
                             }

--- a/firmware/smolusb/src/traits.rs
+++ b/firmware/smolusb/src/traits.rs
@@ -26,8 +26,8 @@ pub trait UsbDriverOperations {
     /// Stall the given OUT endpoint number.
     fn stall_endpoint_out(&self, endpoint_number: u8);
 
-    /// Clear any halt condition on the target endpoint address, and clear the data toggle bit.
-    fn clear_feature_endpoint_halt(&self, endpoint_address: u8);
+    /// Clear a halt condition on the target endpoint address.
+    fn clear_feature_endpoint_halt(&self, endpoint_number: u8, direction: Direction);
 }
 
 /// These are used to deal with the situation where we need to block


### PR DESCRIPTION
This PR fixes a few things:

* Refactor `clear_feature_endpoint_halt` arguments in the USB HAL driver to match stall arguments.
* Add a `clear_feature_endpoint_halt` verb to the Moondancer GCP class.
* Compiler warnings on the latest rustc release.
* Incorrect reference to a Makefile target.
* Fixes a compiler error when ladybug is enabled.

Depends on: https://github.com/greatscottgadgets/facedancer/pull/106