### PR TITLE
docs: fix Tutorials capitalization

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ Cynthion Documentation
 
 .. toctree::
   :maxdepth: 2
-  :caption: tutorials
+  :caption: Tutorials
 
   tutorial_usb_analysis
 


### PR DESCRIPTION
oops