### PR TITLE
Fix Facedancer USB Timeout error

### DIFF
--- a/firmware/lunasoc-hal/src/usb.rs
+++ b/firmware/lunasoc-hal/src/usb.rs
@@ -236,12 +236,14 @@ macro_rules! impl_usb {
 
                 /// Stall the given IN endpoint number.
                 fn stall_endpoint_in(&self, endpoint_number: u8) {
+                    self.ep_in.reset().write(|w| w.reset().bit(true));
                     self.ep_in.stall().write(|w| w.stall().bit(true));
                     self.ep_in.epno().write(|w| unsafe { w.epno().bits(endpoint_number) });
                 }
 
                 /// Stall the given OUT endpoint number.
                 fn stall_endpoint_out(&self, endpoint_number: u8) {
+                    self.ep_out.reset().write(|w| w.reset().bit(true));
                     self.ep_out.epno().write(|w| unsafe { w.epno().bits(endpoint_number) });
                     self.ep_out.stall().write(|w| w.stall().bit(true));
                 }
@@ -512,7 +514,7 @@ macro_rules! impl_usb {
                     //      - no need to prime, fifo is empty
                     //   d. A full packet is sent, followed by a zlp
                     //      - fifo is empty, but need to prime to send a zlp so host know it's EOT
-                    //   e. An emptry packet is sent, followed by a zlp
+                    //   e. An empty packet is sent, followed by a zlp
                     //      - fifo is empty, but need to prime to send a zlp so host know it's EOT
                     //
                     let is_partial_packet = bytes_written % packet_size != 0;

--- a/firmware/moondancer/src/bin/moondancer.rs
+++ b/firmware/moondancer/src/bin/moondancer.rs
@@ -501,15 +501,12 @@ impl<'a> Firmware<'a> {
                     "dispatch_libgreat_request error: failed to dispatch command {:?} 0x{:X} {}",
                     class_id, verb_number, e
                 );
+
                 self.libgreat_response = None;
                 self.libgreat_response_last_error = Some(e);
 
-                // TODO this is... weird...
+                // stall endpoint to trigger dispatch_libgreat_abort from control host
                 self.usb2.stall_endpoint_in(0);
-                unsafe {
-                    riscv::asm::delay(2000);
-                }
-                self.usb2.ep_in.reset().write(|w| w.reset().bit(true));
             }
         }
 
@@ -527,37 +524,39 @@ impl<'a> Firmware<'a> {
             // clear cached response
             self.libgreat_response = None;
 
-            // prime to receive host zlp - aka ep_out_prime_receive() TODO should control do this in send_complete?
+            // prime to receive host zlp
             self.usb2.ep_out_prime_receive(0);
+
         } else if let Some(error) = self.libgreat_response_last_error {
-            warn!("dispatch_libgreat_response error result: {:?}", error);
+            warn!("dispatch_libgreat_response error result: {:?} (reqlen:{})", error, requested_length);
 
-            // prime to receive host zlp - TODO should control do this in send_complete?
-            self.usb2.ep_out_prime_receive(0);
-
-            // write error
-            self.usb2.write(0, (error as u32).to_le_bytes().into_iter());
-
-            // clear cached error
-            self.libgreat_response_last_error = None;
         } else {
-            // TODO figure out what to do if we don't have a response or error
-            error!("dispatch_libgreat_response stall: libgreat response requested but no response or error queued");
             self.usb2.stall_endpoint_in(0);
+            error!("dispatch_libgreat_response stall: libgreat response requested but no response or error queued");
         }
 
         Ok(())
     }
 
-    fn dispatch_libgreat_abort(&mut self, _setup_packet: SetupPacket) -> GreatResult<()> {
-        // send an arbitrary error code if we're aborting mid-response
-        if let Some(_response) = &self.libgreat_response {
-            // prime to receive host zlp - TODO should control do this in send_complete?
+    fn dispatch_libgreat_abort(&mut self, setup_packet: SetupPacket) -> GreatResult<()> {
+        let requested_length = setup_packet.length as usize;
+
+        if let Some(error) = self.libgreat_response_last_error {
+            // send error
+            self.usb2.write_requested(0, requested_length, (error as u32).to_le_bytes().into_iter());
+
+            // prime to receive host zlp
             self.usb2.ep_out_prime_receive(0);
 
-            // TODO send last error code?
-            self.usb2.write(0, 0_u32.to_le_bytes().into_iter());
+            warn!("dispatch_libgreat_abort error result: {:?} (reqlen:{})", error, requested_length);
+
+        } else {
+            self.usb2.write_requested(0, requested_length, (GreatError::StateNotRecoverable as u32).to_le_bytes().into_iter());
+
+            // prime to receive host zlp
+            self.usb2.ep_out_prime_receive(0);
         }
+
 
         // cancel any queued response
         self.libgreat_response = None;

--- a/firmware/moondancer/src/gcp/moondancer.rs
+++ b/firmware/moondancer/src/gcp/moondancer.rs
@@ -256,7 +256,7 @@ impl Moondancer {
 
         // wait for things to settle and get connection speed
         unsafe {
-            riscv::asm::delay(30_000_000);
+            riscv::asm::delay(20_000_000);
         }
         let speed: Speed = self.usb0.controller.speed().read().speed().bits().into();
 


### PR DESCRIPTION
This PR does a few things:

* Update libgreat command abort handling to function as intended now that the most recent release fixed the bugs that were preventing it from functioning in a sane manner.
* Resets the endpoint FIFO's before issuing a stall to ensure that we clear the USB peripheral state for future requests.
* Primes the OUT endpoint to receive the host ZLP before writing a libgreat response.
* Shortens the delay in the libgreat moondancer `connect` verb. This may result in the speed of the interface being reported incorrectly but this bug has been fixed in the upcoming `luna-soc 0.3.x` release.

--- 
closes #188 