### PR TITLE
docs: move tutorials to their own subdirectory

### DIFF
--- a/docs/source/getting_started_packetry.rst
+++ b/docs/source/getting_started_packetry.rst
@@ -58,4 +58,4 @@ Connect Hardware
 
 
 Next, see the `Packetry documentation <https://packetry.readthedocs.io/en/latest/quick_start.html#connect-cynthion>`__ for more detail,
-or the tutorial :doc:`tutorial_usb_analysis` for a worked example.
+or the tutorial :doc:`tutorials/usb_analysis` for a worked example.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,8 +21,8 @@ Cynthion Documentation
   :maxdepth: 2
   :caption: Tutorials
 
-  tutorial_usb_analysis
-  tutorial_emulation
+  tutorials/usb_analysis
+  tutorials/emulation
 
 .. toctree::
   :maxdepth: 2

--- a/docs/source/tutorials/emulation.rst
+++ b/docs/source/tutorials/emulation.rst
@@ -7,9 +7,9 @@ This tutorial walks through the whole process of emulating a USB device with Cyn
 Prerequisites
 -------------
 
- * Install the Cynthion tools by following :doc:`getting_started`.
+ * Install the Cynthion tools by following :doc:`/getting_started`.
  * Install HackRF Tools by following `Installing HackRF Software <https://hackrf.readthedocs.io/en/latest/installing_hackrf_software.html>`__.
- * Install the Facedancer library and run the Facedancer bitstream and firmware as described in :doc:`getting_started_facedancer`.
+ * Install the Facedancer library and run the Facedancer bitstream and firmware as described in :doc:`/getting_started_facedancer`.
 
     .. note::
 
@@ -41,7 +41,7 @@ We need to connect our Cynthion before we can use it to emulate a HackRF One. If
 
 Now also connect the **TARGET C** port to your computer. Facedancer software uses **CONTROL** to control the Cynthion and **TARGET C** to connect to the target host, the computer which we'll try to fool into thinking that there is a HackRF One connected. The control host and target host can be two separate computers, but in this tutorial we will use the same computer as both the control host and the target host.
 
-.. image:: ../images/cynthion-connections-facedancer-single-host.svg
+.. image:: ../../images/cynthion-connections-facedancer-single-host.svg
   :alt: Connection diagram for using Cynthion with Facedancer on a single host computer.
 
 
@@ -204,7 +204,7 @@ While the program is running, execute ``hackrf_info`` in another terminal:
     Serial number: 1234
     Board ID Number: 2 (HackRF One)
     hackrf_version_string_read() failed: Pipe error (-1000)
- 
+
 We did it! Our new board ID represents HackRF One! In this example we guessed low numbers for the board ID byte, but we could have discovered that ``2`` represents HackRF One by observing the behavior of an actual HackRF One or by reading the `libhackrf source code <https://github.com/greatscottgadgets/hackrf/blob/17f394331d16e11d835092bed14a5b7feb4f47e0/host/libhackrf/src/hackrf.h#L660>`__ or `HackRF firmware source code <https://github.com/greatscottgadgets/hackrf/blob/17f394331d16e11d835092bed14a5b7feb4f47e0/host/libhackrf/src/hackrf.h#L660>`__.
 
 

--- a/docs/source/tutorials/usb_analysis.rst
+++ b/docs/source/tutorials/usb_analysis.rst
@@ -7,9 +7,9 @@ though this process is also applicable to any USB peripheral device.
 Prerequisites
 -------------
 
- * Install the Cynthion tools by following :doc:`getting_started`
+ * Install the Cynthion tools by following :doc:`/getting_started`
  * Install Packetry by following `Getting Started with Packetry <https://packetry.readthedocs.io/en/latest/quick_start.html>`_
- * Run the analyzer gateware on Cynthion by following :doc:`getting_started_packetry`
+ * Run the analyzer gateware on Cynthion by following :doc:`/getting_started_packetry`
 
 Determine device speed
 ----------------------
@@ -53,7 +53,7 @@ Connect
 Next, we'll connect everything up for capture. Within the Cynthion hardware the **TARGET C** and **TARGET A** ports are connected together,
 and the analyzer gateware will capture any packets that are seen going between those ports. These packets are then sent out through the **CONTROL** port.
 
-.. image:: ../images/cynthion-connections-packetry.svg
+.. image:: ../../images/cynthion-connections-packetry.svg
   :alt: Connection diagram for using Cynthion with Packetry.
 
 First, connect the **CONTROL** port to the host that will be running Packetry. Next, connect the **TARGET C** port to a host.
@@ -66,17 +66,17 @@ Capture
 
 Open Packetry. At the top of the window, you should see the `action bar <https://packetry.readthedocs.io/en/latest/user_interface.html#action-bar>`_:
 
-.. image:: ../images/tutorial_usb_analysis/action_bar.png
+.. image:: ../../images/tutorial_usb_analysis/action_bar.png
   :alt: Action Bar
 
 Select the correct speed, press the capture button (the filled circle), and plug in the target device. The cable connections should look like this:
 
-.. image:: ../images/tutorial_usb_analysis/setup_photo.jpg
+.. image:: ../../images/tutorial_usb_analysis/setup_photo.jpg
   :alt: Connection diagram for using Cynthion with Packetry
 
 Upon plugging in the target device, a collection of entries should show up in the Traffic Pane, these show the requests that a host makes to find out information about a new device (known as USB enumeration).
 
-.. image:: ../images/tutorial_usb_analysis/demo_kb.png
+.. image:: ../../images/tutorial_usb_analysis/demo_kb.png
   :alt: Packetry application showing a capture
 
 The target device should also show up in the `Devices` pane to the right. All of the entries in the Traffic and Device panes can be expanded for more detail, by clicking on the black triangles.
@@ -84,7 +84,7 @@ Clicking on an entry in the Traffic pane to highlight it will show extra detail 
 
 If you press and release a key on the keyboard, some new entries should show up:
 
-.. image:: ../images/tutorial_usb_analysis/keypress_events.png
+.. image:: ../../images/tutorial_usb_analysis/keypress_events.png
   :alt: Packetry showing two interrupt transfers for a key press-and-release event
 
 Here I pressed the ``a`` key, causing two interrupt transfers; one for the press and one for the release event.
@@ -95,17 +95,17 @@ to learn about the class-specific descriptors and endpoints, and match up what y
 Troubleshooting
 ---------------
 
-Below are some common issues you may run into, with some advice for resolving them. If you run into further issues, please see the :doc:`support/getting_help` section for more support.
+Below are some common issues you may run into, with some advice for resolving them. If you run into further issues, please see the :doc:`/support/getting_help` section for more support.
 
 Capture button is grayed out and no capture device shows up in Packetry
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. image:: ../images/tutorial_usb_analysis/no_capture_device.png
+.. image:: ../../images/tutorial_usb_analysis/no_capture_device.png
   :alt: Action bar showing no capture device available
 
 * Double check that the Cynthion **CONTROL** port is connected to the host running Packetry.
 * Check that the cable is good, ideally trying it with another USB device that transfers data (not just charging).
-* Make sure that the analyzer gateware is running on the Cynthion device by following :doc:`getting_started_packetry`.
+* Make sure that the analyzer gateware is running on the Cynthion device by following :doc:`/getting_started_packetry`.
 
 No traffic shows up during capture
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -116,7 +116,7 @@ If traffic still isn't showing up, this is usually caused by selecting the wrong
 Traffic shows "Invalid Groups"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. image:: ../images/tutorial_usb_analysis/invalid_groups.png
+.. image:: ../../images/tutorial_usb_analysis/invalid_groups.png
   :alt: Packetry traffic pane with many "Invalid groups" entries
 
 This means that the analyzer is detecting packets that are invalid. This is usually caused by selecting the wrong capture speed, try capturing with each of the other two speed options.
@@ -124,7 +124,7 @@ This means that the analyzer is detecting packets that are invalid. This is usua
 Traffic shows "unidentified transfer" and Devices shows an "Unknown" device
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. image:: ../images/tutorial_usb_analysis/unidentified_unknown.png
+.. image:: ../../images/tutorial_usb_analysis/unidentified_unknown.png
   :alt: Packetry showing unidentified transfers and unknown device
 
 This means that valid packets have been captured, but Packetry did not see the target device enumeration so it doesn't have enough information to fully decode the USB transactions/transfers.


### PR DESCRIPTION
This PR moves the tutorials from `/docs/source` to `/docs/source/tutorials`.