### PR TITLE
Add Cynthion Gateware Tutorials

### DIFF
--- a/docs/source/getting_started_packetry.rst
+++ b/docs/source/getting_started_packetry.rst
@@ -58,4 +58,4 @@ Connect Hardware
 
 
 Next, see the `Packetry documentation <https://packetry.readthedocs.io/en/latest/quick_start.html#connect-cynthion>`__ for more detail,
-or the tutorial :doc:`tutorial_usb_analysis` for a worked example.
+or the tutorial :doc:`tutorials/usb_analysis` for a worked example.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,8 +21,8 @@ Cynthion Documentation
   :maxdepth: 2
   :caption: Tutorials
 
-  tutorial_usb_analysis
-  tutorial_emulation
+  tutorials/usb_analysis
+  tutorials/emulation
 
 .. toctree::
   :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,9 @@ Cynthion Documentation
 
   tutorials/usb_analysis
   tutorials/emulation
+  tutorials/gateware_blinky
+  tutorials/gateware_simple_usb_device
+  tutorials/gateware_usb_audio_device
 
 .. toctree::
   :maxdepth: 2

--- a/docs/source/tutorials/emulation.rst
+++ b/docs/source/tutorials/emulation.rst
@@ -7,9 +7,9 @@ This tutorial walks through the whole process of emulating a USB device with Cyn
 Prerequisites
 -------------
 
- * Install the Cynthion tools by following :doc:`getting_started`.
+ * Install the Cynthion tools by following :doc:`/getting_started`.
  * Install HackRF Tools by following `Installing HackRF Software <https://hackrf.readthedocs.io/en/latest/installing_hackrf_software.html>`__.
- * Install the Facedancer library and run the Facedancer bitstream and firmware as described in :doc:`getting_started_facedancer`.
+ * Install the Facedancer library and run the Facedancer bitstream and firmware as described in :doc:`/getting_started_facedancer`.
 
     .. note::
 
@@ -41,7 +41,7 @@ We need to connect our Cynthion before we can use it to emulate a HackRF One. If
 
 Now also connect the **TARGET C** port to your computer. Facedancer software uses **CONTROL** to control the Cynthion and **TARGET C** to connect to the target host, the computer which we'll try to fool into thinking that there is a HackRF One connected. The control host and target host can be two separate computers, but in this tutorial we will use the same computer as both the control host and the target host.
 
-.. image:: ../images/cynthion-connections-facedancer-single-host.svg
+.. image:: ../../images/cynthion-connections-facedancer-single-host.svg
   :alt: Connection diagram for using Cynthion with Facedancer on a single host computer.
 
 
@@ -204,7 +204,7 @@ While the program is running, execute ``hackrf_info`` in another terminal:
     Serial number: 1234
     Board ID Number: 2 (HackRF One)
     hackrf_version_string_read() failed: Pipe error (-1000)
- 
+
 We did it! Our new board ID represents HackRF One! In this example we guessed low numbers for the board ID byte, but we could have discovered that ``2`` represents HackRF One by observing the behavior of an actual HackRF One or by reading the `libhackrf source code <https://github.com/greatscottgadgets/hackrf/blob/17f394331d16e11d835092bed14a5b7feb4f47e0/host/libhackrf/src/hackrf.h#L660>`__ or `HackRF firmware source code <https://github.com/greatscottgadgets/hackrf/blob/17f394331d16e11d835092bed14a5b7feb4f47e0/host/libhackrf/src/hackrf.h#L660>`__.
 
 

--- a/docs/source/tutorials/gateware_blinky.rst
+++ b/docs/source/tutorials/gateware_blinky.rst
@@ -1,0 +1,192 @@
+Gateware Blinky
+===============
+
+This tutorial walks through the process of developing a simple "blinky" example for Cynthion's ECP5 FPGA. We'll use the `Amaranth Language & toolchain <https://amaranth-lang.org>`__ to create the design and generate a FPGA bitstream using the `Yosys Open SYnthesis Suite <https://yosyshq.net/>`__.
+
+
+Prerequisites
+-------------
+
+ * Install the Cynthion tools by following :doc:`/getting_started`
+
+
+Install YoWASP
+--------------
+
+`YoWASP <https://yowasp.org/>`__ provides unofficial WebAssembly-based packages for Yosys and NextPNR. It runs a little slower than the `official OSS CAD Suite distribution <https://github.com/YosysHQ/oss-cad-suite-build>`__ but it's platform-independent and easier to get started with.
+
+You can install YoWASP using pip:
+
+.. code-block :: sh
+
+    pip install yowasp-yosys yowasp-nextpnr-ecp5 # what is amaranth-yosys then?
+
+
+Once YoWASP has been installed the following environment variables need to be set:
+
+.. code-block :: sh
+
+    # FIXME - we should be able to detect yowasp and set these up within top_level_cli
+    export YOSYS=yowasp-yosys \
+           SBY=yowasp-sby \
+           SMTBMC=yowasp-yosys-smtbmc \
+           NEXTPNR_ECP5=yowasp-nextpnr-ecp5 \
+           ECPPACK=yowasp-ecppack
+
+
+Create a new Amaranth module
+----------------------------
+
+Create a new file called ``gateware-blinky.py`` and add the following code to it:
+
+.. code-block :: python
+    :linenos:
+
+    from amaranth import *
+
+    class Top(Elaboratable):
+        def elaborate(self, platform):
+            m = Module()
+            return m
+
+Amaranth designs are built from a hierarchy of smaller modules, which are called `elaboratables`. The ``Top`` class expresses that this will be the top-level or entry-point of your design.
+
+Right now the ``Top`` module does not do anything except to create an Amaranth ``Module()`` and return it from the ``elaborate(...)`` method.
+
+The ``elaborate(...)`` method also takes an argument called ``platform`` that contains resources specific to the board or platform the module is compiled for.
+
+In this case, the argument will be an instance of the `Cynthion Board Description <https://github.com/greatscottgadgets/cynthion/blob/main/cynthion/python/src/gateware/platform/cynthion_r1_4.py>`__ and contain a map of Cynthion resources such as LEDs, USB PHY's, USER PMOD connectors and board constraints.
+
+
+Obtain a platform resource
+--------------------------
+
+Edit ``gateware-blinky.py`` and add the highlighted line:
+
+.. code-block :: python
+    :linenos:
+    :emphasize-lines: 7
+
+    from amaranth import *
+
+    class Top(Elaboratable):
+        def elaborate(self, platform):
+            m = Module()
+
+            leds: Signal(6) = Cat(platform.request("led", n).o for n in range(0, 6))
+
+            return m
+
+Amaranth platform resources can be obtained via the ``platform.request(name, number=0)`` method where ``name`` is the name of the resource and ``number`` is the index of the resource if there are more than one defined.
+
+In this case we use a Python list comprehension to obtain all six FPGA led's and concatenate them into a six-bit addressable Amaranth ``Signal`` using the ``Cat`` operation.
+
+
+Timer State
+-----------
+
+To make the LED blink at predictable intervals we'll use a simple timer.
+
+To start with, let's define the timer state by adding the highlighted lines:
+
+.. code-block :: python
+    :linenos:
+    :emphasize-lines: 9-10
+
+    from amaranth import *
+
+    class Top(Elaboratable):
+        def elaborate(self, platform):
+            m = Module()
+
+            leds: Signal(6) = Cat(platform.request("led", n).o for n in range(0, 6))
+
+            half_freq: int    = int(60e6 // 2)
+            timer: Signal(25) = Signal(range(half_freq + 1))
+
+            return m
+
+First we'll declare a variable ``half_freq`` which is exactly half of Cynthion FPGA's default clock frequency in Hz, next we'll declare ``timer`` to be an Amaranth ``Signal`` which is wide enough to contain a value equal to ``half_freq + 1``.
+
+If we increment the ``timer`` by one for each clock cycle until it reaches ``half_freq`` we get a timer with a 500ms period.
+
+
+Timer Logic
+-----------
+
+Now that we have a state definition for our timer we can move forward to the implementation logic, edit your file and add the highlighted lines:
+
+.. code-block :: python
+    :linenos:
+    :emphasize-lines: 12-17
+
+    from amaranth import *
+
+    class Top(Elaboratable):
+        def elaborate(self, platform):
+            m = Module()
+
+            leds: Signal(6) = Cat(platform.request("led", n).o for n in range(0, 6))
+
+            half_freq: int    = int(60e6 // 2)
+            timer: Signal(25) = Signal(range(half_freq + 1))
+
+            with m.If(timer == half_freq):
+                m.d.sync += leds.eq(~leds)
+                m.d.sync += timer.eq(0)
+
+            with m.Else():
+                m.d.sync += timer.eq(timer + 1)
+
+            return m
+
+Amaranth combines normal Python expressions with Amaranth in order to describe a design. Whenever you see the prefix ``m.`` you are making a call to the ``Module`` object you created at the beginning of the ``elaborate(...)`` method. These calls are what build the logic which makes up a design.
+
+The ``with m.If(...):`` and ``with m.Else():`` blocks operate much like you'd expect where, every clock-cycle, the expression ``timer == half_freq`` will be evaluated and trigger the corresponding branch.
+
+The first block represents the point at which the timer has expired and we'd like to change the state of the LEDs and then reset the timer back to zero.
+
+In the second block the timer is still active so we simply increment ``timer`` by one.
+
+
+
+
+
+State can be represented in Amaranth by ``Signal`` objects subject to Combinational or Synchronous evaluation.
+
+.. note:: If you've worked with Verilog before, Combination and Synchronous evaluation corresponds roughly to ``assign`` and ``always``.
+
+
+
+
+
+
+Put It All Together
+-------------------
+
+The contents of ``gateware-blinky.py`` should now look like this:
+
+.. literalinclude:: ../../../cynthion/python/examples/gateware-blinky.py
+   :language: python
+   :linenos:
+
+
+Build and Upload FPGA Bitstream
+-------------------------------
+
+Make sure your Cynthion CONTROL port is plugged into the host, open a terminal and then run:
+
+.. code-block :: sh
+
+    python gateware-blinky.py
+
+The blinky gateware will now be synthesized, placeed, routed and automatically uploaded to the Cynthion's FPGA.
+
+Once this process has completed successfully all six of Cynthion's FPGA LEDs should be flashing on and off.
+
+
+
+More information:
+-----------------
+
+For more information on Amaranth please see the `Amaranth Language & tool change documentation <https://amaranth-lang.org/docs/amaranth/>`__.

--- a/docs/source/tutorials/gateware_simple_usb_device.rst
+++ b/docs/source/tutorials/gateware_simple_usb_device.rst
@@ -1,0 +1,51 @@
+Simple USB Gateware Device
+==========================
+
+This tutorial walks through the process of implementing a USB device with Cynthion and `LUNA <https://luna.readthedocs.io/>`__. We'll implement a simple device with two bulk endpoints. The goal of this tutorial is to demonstrate how to send and receive data between a host and a Cynthion gateware device.
+
+Prerequisites
+-------------
+
+ * Install the Cynthion tools by following :doc:`/getting_started`.
+ * Complete the :doc:`/tutorials/gateware_blinky` tutorial.
+
+
+How do USB Bulk Transfers Work?
+-------------------------------
+
+
+
+Device Descriptor
+-----------------
+
+
+
+Device Endpoints
+----------------
+
+* Map inputs & outputs to endpoints.
+* IN endpoint is the state of the Cynthion USER button.
+* OUT endpoint is the Cynthion FPGA LEDs.
+
+
+
+Implement the Bulk Out Endpoint
+-------------------------------
+
+
+
+
+Implement the Bulk In Endpoint
+------------------------------
+
+
+Testing the Device
+------------------
+
+
+
+Exercises
+---------
+
+1. Modify the tutorial to work with a Cynthion USER PMOD port
+2.

--- a/docs/source/tutorials/gateware_usb_audio_device.rst
+++ b/docs/source/tutorials/gateware_usb_audio_device.rst
@@ -1,0 +1,26 @@
+USB Audio Class Gateware Device
+===============================
+
+This tutorial walks through the process of implementing a USB device with Cynthion and `LUNA <https://luna.readthedocs.io/>`__. We'll implement a simple `USB Audio Class 2.0 <https://www.usb.org/document-library/audio-devices-rev-20-and-adopters-agreement>`__ device. The goal of this tutorial is to create a simple audio device that can provide audio data to the host operating system.
+
+Prerequisites
+-------------
+
+ * Install the Cynthion tools by following :doc:`/getting_started`.
+ * Complete the :doc:`/tutorials/gateware_blinky` tutorial.
+
+
+About USB Audio Class 2.0
+-------------------------
+
+
+Device Descriptor
+-----------------
+
+
+Device Endpoints
+----------------
+
+
+Audio Data
+----------

--- a/docs/source/tutorials/usb_analysis.rst
+++ b/docs/source/tutorials/usb_analysis.rst
@@ -7,9 +7,9 @@ though this process is also applicable to any USB peripheral device.
 Prerequisites
 -------------
 
- * Install the Cynthion tools by following :doc:`getting_started`
+ * Install the Cynthion tools by following :doc:`/getting_started`
  * Install Packetry by following `Getting Started with Packetry <https://packetry.readthedocs.io/en/latest/quick_start.html>`_
- * Run the analyzer gateware on Cynthion by following :doc:`getting_started_packetry`
+ * Run the analyzer gateware on Cynthion by following :doc:`/getting_started_packetry`
 
 Determine device speed
 ----------------------
@@ -53,7 +53,7 @@ Connect
 Next, we'll connect everything up for capture. Within the Cynthion hardware the **TARGET C** and **TARGET A** ports are connected together,
 and the analyzer gateware will capture any packets that are seen going between those ports. These packets are then sent out through the **CONTROL** port.
 
-.. image:: ../images/cynthion-connections-packetry.svg
+.. image:: ../../images/cynthion-connections-packetry.svg
   :alt: Connection diagram for using Cynthion with Packetry.
 
 First, connect the **CONTROL** port to the host that will be running Packetry. Next, connect the **TARGET C** port to a host.
@@ -66,17 +66,17 @@ Capture
 
 Open Packetry. At the top of the window, you should see the `action bar <https://packetry.readthedocs.io/en/latest/user_interface.html#action-bar>`_:
 
-.. image:: ../images/tutorial_usb_analysis/action_bar.png
+.. image:: ../../images/tutorial_usb_analysis/action_bar.png
   :alt: Action Bar
 
 Select the correct speed, press the capture button (the filled circle), and plug in the target device. The cable connections should look like this:
 
-.. image:: ../images/tutorial_usb_analysis/setup_photo.jpg
+.. image:: ../../images/tutorial_usb_analysis/setup_photo.jpg
   :alt: Connection diagram for using Cynthion with Packetry
 
 Upon plugging in the target device, a collection of entries should show up in the Traffic Pane, these show the requests that a host makes to find out information about a new device (known as USB enumeration).
 
-.. image:: ../images/tutorial_usb_analysis/demo_kb.png
+.. image:: ../../images/tutorial_usb_analysis/demo_kb.png
   :alt: Packetry application showing a capture
 
 The target device should also show up in the `Devices` pane to the right. All of the entries in the Traffic and Device panes can be expanded for more detail, by clicking on the black triangles.
@@ -84,7 +84,7 @@ Clicking on an entry in the Traffic pane to highlight it will show extra detail 
 
 If you press and release a key on the keyboard, some new entries should show up:
 
-.. image:: ../images/tutorial_usb_analysis/keypress_events.png
+.. image:: ../../images/tutorial_usb_analysis/keypress_events.png
   :alt: Packetry showing two interrupt transfers for a key press-and-release event
 
 Here I pressed the ``a`` key, causing two interrupt transfers; one for the press and one for the release event.
@@ -95,17 +95,17 @@ to learn about the class-specific descriptors and endpoints, and match up what y
 Troubleshooting
 ---------------
 
-Below are some common issues you may run into, with some advice for resolving them. If you run into further issues, please see the :doc:`support/getting_help` section for more support.
+Below are some common issues you may run into, with some advice for resolving them. If you run into further issues, please see the :doc:`/support/getting_help` section for more support.
 
 Capture button is grayed out and no capture device shows up in Packetry
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. image:: ../images/tutorial_usb_analysis/no_capture_device.png
+.. image:: ../../images/tutorial_usb_analysis/no_capture_device.png
   :alt: Action bar showing no capture device available
 
 * Double check that the Cynthion **CONTROL** port is connected to the host running Packetry.
 * Check that the cable is good, ideally trying it with another USB device that transfers data (not just charging).
-* Make sure that the analyzer gateware is running on the Cynthion device by following :doc:`getting_started_packetry`.
+* Make sure that the analyzer gateware is running on the Cynthion device by following :doc:`/getting_started_packetry`.
 
 No traffic shows up during capture
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -116,7 +116,7 @@ If traffic still isn't showing up, this is usually caused by selecting the wrong
 Traffic shows "Invalid Groups"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. image:: ../images/tutorial_usb_analysis/invalid_groups.png
+.. image:: ../../images/tutorial_usb_analysis/invalid_groups.png
   :alt: Packetry traffic pane with many "Invalid groups" entries
 
 This means that the analyzer is detecting packets that are invalid. This is usually caused by selecting the wrong capture speed, try capturing with each of the other two speed options.
@@ -124,7 +124,7 @@ This means that the analyzer is detecting packets that are invalid. This is usua
 Traffic shows "unidentified transfer" and Devices shows an "Unknown" device
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. image:: ../images/tutorial_usb_analysis/unidentified_unknown.png
+.. image:: ../../images/tutorial_usb_analysis/unidentified_unknown.png
   :alt: Packetry showing unidentified transfers and unknown device
 
 This means that valid packets have been captured, but Packetry did not see the target device enumeration so it doesn't have enough information to fully decode the USB transactions/transfers.


### PR DESCRIPTION
This PR adds three Gateware tutorials of increasing complexity to the documentation:

1. **Gateware Blinky** - Ye olde blinky. Includes instructions for installing the FPGA toolchain and uploading bitstreams.
2. **Simple USB Device** - A simple introduction to moving information between the host and Cynthion using gateware.
3. **USB Audio Class Device** - A simple USB Audio Class Device that can send and receive audio data.