### PR TITLE
pac: bump critical-section crate to version =1.2.0

### DIFF
--- a/firmware/moondancer-pac/CHANGELOG.md
+++ b/firmware/moondancer-pac/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!--
 ## [Unreleased]
+### Changed
+- Bump `critical-section` to version `=1.2.0` as older versions have been yanked from crates.io. (tx @goo99x!)
+
 -->
 
 ## [0.1.1] - 2024-07-08

--- a/firmware/moondancer-pac/Cargo.toml
+++ b/firmware/moondancer-pac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moondancer-pac"
-version = "0.1.1"
+version = "0.1.8"
 authors = ["Great Scott Gadgets <dev@greatscottgadgets.com>"]
 license = "BSD-3-Clause"
 description = "A peripheral access crate for the Cynthion Moondancer SoC"
@@ -32,7 +32,7 @@ minerva = []
 vexriscv = []
 
 [dependencies]
-critical-section = { version = "=1.1.1", optional = true }
+critical-section = { version = "=1.2.0", optional = true }
 riscv = "=0.10.1"
 riscv-rt = { version = "=0.11.0", optional = true }
 vcell = "=0.1.3"


### PR DESCRIPTION
All previous versions of the critical-section crate have been pulled from crates.io due to a soundness issue. This PR bumps us to the current release which contains the fixes.

---
Closes #198 