### PR TITLE
Fix facedancer unittests

### DIFF
--- a/firmware/lunasoc-hal/src/usb.rs
+++ b/firmware/lunasoc-hal/src/usb.rs
@@ -155,6 +155,15 @@ macro_rules! impl_usb {
                     // disable endpoint events
                     self.disable_events();
 
+                    // un-prime all OUT endpoints and disable interface
+                    for endpoint_number in 0..smolusb::EP_MAX_ENDPOINTS as u8 {
+                        self.ep_out
+                            .epno()
+                            .write(|w| unsafe { w.epno().bits(endpoint_number) });
+                        self.ep_out.prime().write(|w| w.prime().bit(false));
+                    }
+                    self.ep_out.enable().write(|w| w.enable().bit(false));
+
                     // reset FIFOs
                     self.ep_control.reset().write(|w| w.reset().bit(true));
                     self.ep_in.reset().write(|w| w.reset().bit(true));
@@ -179,6 +188,15 @@ macro_rules! impl_usb {
 
                     // disconnect device controller
                     self.controller.connect().write(|w| w.connect().bit(false));
+
+                    // un-prime all OUT endpoints and disable interface
+                    for endpoint_number in 0..smolusb::EP_MAX_ENDPOINTS as u8 {
+                        self.ep_out
+                            .epno()
+                            .write(|w| unsafe { w.epno().bits(endpoint_number) });
+                        self.ep_out.prime().write(|w| w.prime().bit(false));
+                    }
+                    self.ep_out.enable().write(|w| w.enable().bit(false));
 
                     // reset FIFOs
                     self.ep_control.reset().write(|w| w.reset().bit(true));

--- a/firmware/moondancer/src/gcp/moondancer.rs
+++ b/firmware/moondancer/src/gcp/moondancer.rs
@@ -114,21 +114,6 @@ impl Moondancer {
                     // send ZLP to host to end status stage
                     self.usb0.ack(endpoint_number, Direction::HostToDevice);
                     return;
-                } else if matches!(
-                    (direction, request_type, request),
-                    (
-                        Direction::HostToDevice,
-                        RequestType::Standard,
-                        Request::SetInterface,
-                    )
-                ) {
-                    // reset PID for all endpoints
-                    for endpoint_number in 1..16 {
-                        self.usb0
-                            .clear_feature_endpoint_halt(endpoint_number, Direction::HostToDevice);
-                        self.usb0
-                            .clear_feature_endpoint_halt(endpoint_number, Direction::DeviceToHost);
-                    }
                 }
 
                 // queue setup packet and convert to a control event

--- a/firmware/moondancer/src/gcp/moondancer.rs
+++ b/firmware/moondancer/src/gcp/moondancer.rs
@@ -96,6 +96,7 @@ impl Moondancer {
                 let direction = setup_packet.direction();
                 let request_type = setup_packet.request_type();
                 let request = setup_packet.request();
+
                 if matches!(
                     (direction, request_type, request),
                     (
@@ -113,6 +114,21 @@ impl Moondancer {
                     // send ZLP to host to end status stage
                     self.usb0.ack(endpoint_number, Direction::HostToDevice);
                     return;
+                } else if matches!(
+                    (direction, request_type, request),
+                    (
+                        Direction::HostToDevice,
+                        RequestType::Standard,
+                        Request::SetInterface,
+                    )
+                ) {
+                    // reset PID for all endpoints
+                    for endpoint_number in 1..16 {
+                        self.usb0
+                            .clear_feature_endpoint_halt(endpoint_number, Direction::HostToDevice);
+                        self.usb0
+                            .clear_feature_endpoint_halt(endpoint_number, Direction::DeviceToHost);
+                    }
                 }
 
                 // queue setup packet and convert to a control event
@@ -586,6 +602,24 @@ impl Moondancer {
         Ok([].into_iter())
     }
 
+    pub fn ep_out_interface_enable(
+        &mut self,
+        _arguments: &[u8],
+    ) -> GreatResult<impl Iterator<Item = u8>> {
+        // 0. clear receive fifo in case the previous transaction wasn't handled
+        if self.usb0.ep_out.have().read().have().bit() {
+            log::warn!("Re-enabling interface with unread data: Usb0");
+            self.usb0.ep_out.reset().write(|w| w.reset().bit(true));
+        }
+
+        // 1. re-enable ep_out interface
+        self.usb0.ep_out.enable().write(|w| w.enable().bit(true));
+
+        debug!("MD moondancer::ep_out_interface_enable()");
+
+        Ok([].into_iter())
+    }
+
     pub fn write_control_endpoint(
         &mut self,
         arguments: &[u8],
@@ -885,7 +919,7 @@ pub static CLASS_DOCS: &str = "API for fine-grained control of the Target USB po
 ///
 /// Fields are `"\0"`  where C implementation has `""`
 /// Fields are `"*\0"` where C implementation has `NULL`
-pub static VERBS: [Verb; 18] = [
+pub static VERBS: [Verb; 19] = [
     // - device connection --
     Verb {
         id: 0x00,
@@ -1024,6 +1058,15 @@ pub static VERBS: [Verb; 18] = [
         in_param_names: "*\0",
         out_signature: "<H\0",
         out_param_names: "bitmask\0",
+    },
+    Verb {
+        id: 0x0f,
+        name: "ep_out_interface_enable\0",
+        doc: "\0", //"Enable OUT endpoints to resume receiving packets.\0",
+        in_signature: "\0",
+        in_param_names: "*\0",
+        out_signature: "\0",
+        out_param_names: "*\0",
     },
     // - tests --
     Verb {
@@ -1164,6 +1207,12 @@ impl GreatDispatch for Moondancer {
             0x0e => {
                 // moondancer::get_nak_status
                 let iter = self.get_nak_status(arguments)?;
+                let response = iter_to_response(iter, response_buffer);
+                Ok(response)
+            }
+            0x0f => {
+                // moondancer::ep_out_interface_enable
+                let iter = self.ep_out_interface_enable(arguments)?;
                 let response = iter_to_response(iter, response_buffer);
                 Ok(response)
             }


### PR DESCRIPTION
This PR is part of:
* https://github.com/greatscottgadgets/luna-soc/pull/35
* https://github.com/greatscottgadgets/facedancer/pull/124

---

This PR adds some supporting machinery to fix the Facedancer alternate interface unit tests:

* When connecting/disconnecting a USB device pre-existing endpoints from a previous session may still be primed.
* After moondancer receives a set interface request, the underlying eptri ep_out gateware pid state has a 50% chance of being incorrect.
* Added a moondancer method to re-enable the OUT interface for packet reception.