### PR TITLE
firmware: use correct usb hal write function for facedancer control endpoint

### DIFF
--- a/firmware/moondancer/src/gcp/moondancer.rs
+++ b/firmware/moondancer/src/gcp/moondancer.rs
@@ -636,10 +636,11 @@ impl Moondancer {
         let iter = args.payload.iter();
         let max_packet_size = self.ep_in_max_packet_size[endpoint_number as usize] as usize;
 
-        let bytes_written = self.usb0.write_requested(
+        let bytes_written = self.usb0.write_with_packet_size(
             endpoint_number,
-            requested_length.into(),
+            Some(requested_length.into()),
             iter.copied().take(requested_length.into()),
+            max_packet_size,
         );
 
         // wait for send to complete if we're blocking


### PR DESCRIPTION
When usb packets are sent from facedancer on the control endpoint the data was not packetized according to the configured max_packet_size for endpoint 0.

This PR uses the correct usb hal method to specify the desired `max_packet_size` for endpoint 0.


--- 
Closes https://github.com/greatscottgadgets/facedancer/issues/156