### PR TITLE
gateware: use block RAM again for string descriptors

### DIFF
--- a/cynthion/python/examples/tutorials/gateware-usb-device-02.py
+++ b/cynthion/python/examples/tutorials/gateware-usb-device-02.py
@@ -63,13 +63,7 @@ class GatewareUSBDevice(Elaboratable):
 
         # create our standard descriptors and add them to the device's control endpoint
         descriptors = self.create_standard_descriptors()
-        control_endpoint = usb.add_standard_control_endpoint(
-            descriptors,
-            # the blockram descriptor handler lacks support for
-            # non-contiguous string descriptor indices, which is
-            # required for the Microsoft OS string descriptor at 0xEE
-            avoid_blockram=True,
-        )
+        control_endpoint = usb.add_standard_control_endpoint(descriptors)
 
         # add the microsoft os string descriptor
         descriptors.add_descriptor(get_string_descriptor("MSFT100\xee"), index=0xee)

--- a/cynthion/python/examples/tutorials/gateware-usb-device-03.py
+++ b/cynthion/python/examples/tutorials/gateware-usb-device-03.py
@@ -138,13 +138,7 @@ class GatewareUSBDevice(Elaboratable):
 
         # create our standard descriptors and add them to the device's control endpoint
         descriptors = self.create_standard_descriptors()
-        control_endpoint = usb.add_standard_control_endpoint(
-            descriptors,
-            # the blockram descriptor handler lacks support for
-            # non-contiguous string descriptor indices, which is
-            # required for the Microsoft OS string descriptor at 0xEE
-            avoid_blockram=True,
-        )
+        control_endpoint = usb.add_standard_control_endpoint(descriptors)
 
         # add microsoft os 1.0 descriptors and request handler
         descriptors.add_descriptor(get_string_descriptor("MSFT100\xee"), index=0xee)

--- a/cynthion/python/examples/tutorials/gateware-usb-device-04.py
+++ b/cynthion/python/examples/tutorials/gateware-usb-device-04.py
@@ -153,13 +153,7 @@ class GatewareUSBDevice(Elaboratable):
 
         # create our standard descriptors and add them to the device's control endpoint
         descriptors = self.create_standard_descriptors()
-        control_endpoint = usb.add_standard_control_endpoint(
-            descriptors,
-            # the blockram descriptor handler lacks support for
-            # non-contiguous string descriptor indices, which is
-            # required for the Microsoft OS string descriptor at 0xEE
-            avoid_blockram=True,
-        )
+        control_endpoint = usb.add_standard_control_endpoint(descriptors)
 
         # add microsoft os 1.0 descriptors and request handler
         descriptors.add_descriptor(get_string_descriptor("MSFT100\xee"), index=0xee)

--- a/cynthion/python/src/gateware/analyzer/top.py
+++ b/cynthion/python/src/gateware/analyzer/top.py
@@ -300,7 +300,7 @@ class USBAnalyzerApplet(Elaboratable):
                 p.PropertyData       = "{88bae032-5a81-49f0-bc3d-a4ff138216d6}"
 
         # Add our standard control endpoint to the device.
-        control_endpoint = usb.add_standard_control_endpoint(descriptors, avoid_blockram=True)
+        control_endpoint = usb.add_standard_control_endpoint(descriptors)
 
         # Add handler for Microsoft descriptors.
         msft_handler = MicrosoftOS10RequestHandler(msft_descriptors, request_code=0xee)
@@ -442,7 +442,6 @@ class AnalyzerTestDevice(Elaboratable):
             handler = StandardRequestHandler(
                 self.create_descriptors(speed),
                 self.EP0_MAX_SIZE[speed],
-                avoid_blockram=True,
                 blacklist=[lambda setup,speed=speed: current_speed != speed])
             control_ep.add_request_handler(handler)
 

--- a/docs/source/tutorials/gateware_usb_device_02.rst
+++ b/docs/source/tutorials/gateware_usb_device_02.rst
@@ -72,13 +72,7 @@ To start with, edit your ``gateware-usb-device.py`` file from the previous tutor
 
             # create our standard descriptors and add them to the device's control endpoint
             descriptors = self.create_standard_descriptors()
-            control_endpoint = usb.add_standard_control_endpoint(
-                descriptors,
-                # the blockram descriptor handler lacks support for
-                # non-contiguous string descriptor indices, which is
-                # required for the Microsoft OS string descriptor at 0xEE.
-                avoid_blockram=True,
-            )
+            control_endpoint = usb.add_standard_control_endpoint(descriptors)
 
             # add the microsoft os string descriptor
             descriptors.add_descriptor(get_string_descriptor("MSFT100\xee"), index=0xee)

--- a/docs/source/tutorials/gateware_usb_device_03.rst
+++ b/docs/source/tutorials/gateware_usb_device_03.rst
@@ -109,10 +109,7 @@ To implement vendor requests, begin by adding a ``VendorRequestHandler`` to our 
 
             # create our standard descriptors and add them to the device's control endpoint
             descriptors = self.create_standard_descriptors()
-            control_endpoint = usb.add_standard_control_endpoint(
-                descriptors,
-                avoid_blockram=True,
-            )
+            control_endpoint = usb.add_standard_control_endpoint(descriptors)
 
             # add microsoft os 1.0 descriptors and request handler
             descriptors.add_descriptor(get_string_descriptor("MSFT100\xee"), index=0xee)


### PR DESCRIPTION
support for non-contiguous string descriptor indexes in block RAM was fixed in greatscottgadgets/luna#292