### PR TITLE
gateware: increase facedancer softcore startup delay

### DIFF
--- a/cynthion/python/src/gateware/facedancer/top.py
+++ b/cynthion/python/src/gateware/facedancer/top.py
@@ -324,7 +324,7 @@ class Soc(Component):
         m.submodules += self.wb_to_csr
 
         # wire up the cpu external reset signal
-        delay = Signal(18)
+        delay = Signal(20)
         with m.If(~delay.all()):
             m.d.sync += delay.eq(delay + 1)
             m.d.comb += self.cpu.ext_reset.eq(1)


### PR DESCRIPTION
When attempting `cynthion run facedancer` on some machines the bitstream configuration will fail due to facedancer's softcore taking over the jtag lines post-reset.

This was previously addressed in 9ecf5d77cfc2efc05ed25ec9b3d00d0204a3277d.

This PR increases the softcore's reset delay to provide a larger margin of safety.

closes #245