### PR TITLE
ci: add protocol to docker build URLs to support latest docker CLI changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@ pipeline {
     stages {
         stage('Build Docker Images') {
             steps {
-                sh 'docker build -t cynthion github.com/greatscottgadgets/cynthion'
-                sh 'docker build -t cynthion-test github.com/greatscottgadgets/cynthion-test'
+                sh 'docker build -t cynthion https://github.com/greatscottgadgets/cynthion.git'
+                sh 'docker build -t cynthion-test https://github.com/greatscottgadgets/cynthion-test.git'
             }
         }
         stage('Cynthion selftest') {


### PR DESCRIPTION
This will fail Jenkins CI as that uses the existing version of the Jenkinsfile to run the builds for security; here's a passing replay using these changes - https://jenkins.greatscottgadgets.com/job/grvvy/job/cynthion/job/main/8/console