### PR TITLE
ISSUE-216: cli: add 'cynthion reset' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to the `cynthion` Python package will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!--
 ## [Unreleased]
--->
+### Added
+* New `cynthion reset` command to reset the FPGA and reconfigure it from flash. (#216)
 
 ## [0.2.5] - 2026-05-22
 ### Added

--- a/cynthion/python/src/commands/__init__.py
+++ b/cynthion/python/src/commands/__init__.py
@@ -10,6 +10,7 @@
 from .cynthion_build           import *
 from .cynthion_info            import *
 from .cynthion_flash           import *
+from .cynthion_reset           import *
 from .cynthion_run             import *
 from .cynthion_setup           import *
 from .cynthion_update          import *

--- a/cynthion/python/src/commands/cli.py
+++ b/cynthion/python/src/commands/cli.py
@@ -17,7 +17,7 @@ from apollo_fpga               import ApolloDebugger
 
 from .util                     import HelpFormatter
 
-from . import cynthion_info, cynthion_flash, cynthion_build, cynthion_run, cynthion_setup, cynthion_update
+from . import cynthion_info, cynthion_flash, cynthion_build, cynthion_reset, cynthion_run, cynthion_setup, cynthion_update
 
 
 def main():
@@ -63,6 +63,12 @@ def main():
     update_parser.set_defaults(func=cynthion_update)
     update_parser.add_argument("--mcu-firmware", action='store_true',   help="only update the MCU firmware")
     update_parser.add_argument("--bitstream", action='store_true', help="only update the FPGA bitstream")
+
+    # cynthion reset
+    reset_parser = command_parsers.add_parser("reset", help="reset the FPGA and reconfigure it from flash",
+                                              description="Reset the Cynthion FPGA and reconfigure it from the bitstream stored in configuration flash. Equivalent to pressing the RESET button.",
+                                              formatter_class=HelpFormatter)
+    reset_parser.set_defaults(func=cynthion_reset)
 
     # cynthion info
     info_parser = command_parsers.add_parser("info", help="print device information", formatter_class=HelpFormatter)

--- a/cynthion/python/src/commands/cynthion_reset.py
+++ b/cynthion/python/src/commands/cynthion_reset.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+#
+# This file is part of Cynthion.
+#
+# Copyright (c) 2026 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+""" Cynthion 'reset' command. """
+
+import logging, time
+
+import usb.core
+
+from cynthion import shared
+
+
+def cynthion_reset(device, args):
+    logging.info("Resetting device...")
+
+    # reset device
+    device.soft_reset()
+
+    # let the gateware take over in devices with a shared usb port
+    device.allow_fpga_takeover_usb()
+
+    # wait for the gateware to enumerate
+    if _wait_for_gateware():
+        logging.info("Operation complete!")
+    else:
+        logging.warning("Reset requested, but the Cynthion gateware did not enumerate.")
+        logging.warning("The FPGA configuration flash may not contain a valid bitstream.")
+
+
+def _wait_for_gateware(timeout=5.0):
+    """Polls the USB bus until the Cynthion gateware enumerates or the timeout expires"""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if usb.core.find(idVendor=shared.usb.bVendorId.cynthion,
+                         idProduct=shared.usb.bProductId.cynthion) is not None:
+            return True
+        time.sleep(0.25)
+    return False

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -4,7 +4,7 @@ The ``cynthion`` command line interface
 
 .. code:: text
 
-    $ apollo
+    $ cynthion
     usage: cynthion [-h] command ...
 
     Cynthion command line interface
@@ -15,6 +15,7 @@ The ``cynthion`` command line interface
         flash     overwrite the FPGA's configuration flash with the target bitstream
         update    update MCU firmware and FPGA configuration flash to the latest
                   installed versions
+        reset     reset the FPGA and reconfigure it from flash
         info      print device information
         setup     install Cynthion support files required for operation (Linux only)
 
@@ -43,8 +44,8 @@ Display Cynthion Microcontroller information:
 .. note::
 
     Once you have switched to the Cynthion Microcontroller by pressing the PROGRAM button or
-    the ``--force-offline`` option you will need to press the RESET button to return control
-    to the FPGA.
+    the ``--force-offline`` option you will need to press the RESET button or run
+    ``cynthion reset`` to return control to the FPGA.
 
 
 Set up Cynthion
@@ -89,6 +90,16 @@ Update Cynthion USB Analyzer bitstream to the latest installed factory version:
 .. code-block :: sh
 
     cynthion update --bitstream
+
+
+Reset Cynthion
+^^^^^^^^^^^^^^
+
+Reset the FPGA and reconfigure it from flash, returning control to the FPGA:
+
+.. code-block :: sh
+
+    cynthion reset
 
 
 Run bitstream


### PR DESCRIPTION
Added a new `reset` subcommand to the cynthion CLI that calls `device.soft_reset()` to reset the FPGA and reconfigure it from flash.  It then calls `device.allow_fpga_takeover_usb()` so the gateware can take over on devices with a shared USB port.

This mirrors the behavior of `apollo reconfigure` and provides a supported alternative to pressing the physical RESET button (ie. after taking the FPGA offline with `cynthion info --force-offline`).

I tested this on my Cynthion using the following steps:

```
# install branch build
$ cd cynthion/python && pip install --upgrade .

# static checks
$ cynthion --help                       # reset listed
$ cynthion reset --help                 # description present
$ cynthion setup --check                # correctly rejected: setup is Linux only

# force-offline recovery cycle
$ cynthion info                         # baseline: analyzer responding
$ cynthion info --force-offline         # LEDs B/C/D dark, Apollo mode
$ cynthion reset                        # LEDs B/C/D relit
$ cynthion info                         # USB Analyzer 1d50:615b responding

# flash-revert cycle (release env supplies bitstream assets)
$ cynthion flash analyzer               # failed in branch env: no assets (expected guard)
$ cynthion run selftest                 # failed in branch env: no assets (expected guard)
$ python3 -m venv /tmp/cyn-release && source /tmp/cyn-release/bin/activate && pip install cynthion
$ which cynthion && hash -r && which cynthion    # fixed stale zsh command hash
$ cynthion info | head -1               # confirmed release 0.2.5 live
$ cynthion flash analyzer               # stock analyzer (238,282 B) written to flash
$ cynthion run selftest                 # selftest from SRAM; all 5 hardware tests passed
$ deactivate && hash -r
$ cynthion info | head -2               # confirmed branch 0.0.0 live
$ cynthion reset                        # branch code, from full Apollo mode
$ cynthion info                         # analyzer back from flash → pass
```

Resolves greatscottgadgets/cynthion#216